### PR TITLE
Start in light mode

### DIFF
--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -7,7 +7,8 @@ export function ThemeProvider({ children }) {
   const [dark, setDark] = useState(() => {
     const saved = localStorage.getItem('theme');
     if (saved) return saved === 'dark';
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    // Default to light mode when no preference has been saved
+    return false;
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- default to light theme if user hasn't saved a preference

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686869d592e48331ad2356e6d7e435f0