### PR TITLE
Improve dark mode visuals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,7 @@ export default function App() {
         <Sidebar />
         <div className="flex-1 flex flex-col overflow-hidden">
           <Header toggleDark={toggle} />
-          <main className="flex-1 overflow-auto p-6 bg-gray-50 dark:bg-gray-800">
+          <main className="flex-1 overflow-auto p-6 bg-gray-50 dark:bg-gray-800 dark:shadow-inner">
             <AnimatePresence mode="wait">
               <motion.div
                 key={location.pathname}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -66,7 +66,7 @@ export default function Header({ toggleDark }) {
             className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition"
             aria-label="Déconnexion"
           >
-            <User size={18} />
+            <User size={18} className="text-gray-600 dark:text-gray-100" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add subtle inner shadow to main layout in dark mode
- ensure profile icon uses contrasting color in dark mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68686eafa7608331af17744434332fbd