### PR TITLE
Improve mobile navigation and dark UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTheme } from './context/ThemeContext';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import Sidebar from './components/Sidebar';
+import MobileSidebar from './components/MobileSidebar';
 import Header from './components/Header';
 import Dashboard from './pages/Dashboard';
 import StrategicView from './pages/StrategicView';
@@ -15,14 +16,16 @@ import Profile from './pages/Profile';
 export default function App() {
   const { dark, toggle } = useTheme();
   const location = useLocation();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
     <div className={dark ? 'dark' : ''}>
       <div className="h-screen flex">
         <Sidebar />
+        <MobileSidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <div className="flex-1 flex flex-col overflow-hidden">
-          <Header toggleDark={toggle} />
-          <main className="flex-1 overflow-auto p-6 bg-gray-50 dark:bg-gray-800 dark:shadow-inner">
+          <Header toggleDark={toggle} onOpenSidebar={() => setSidebarOpen(true)} />
+          <main className="flex-1 overflow-auto p-6 bg-white dark:bg-gray-900 shadow md:rounded-2xl m-2">
             <AnimatePresence mode="wait">
               <motion.div
                 key={location.pathname}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
-import { Search, Sun, Moon, User } from 'lucide-react';
+import { Search, Sun, Moon, User, Menu } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { NotificationButton, useNotifications } from './notification-system';
 import { useAuth } from '../context/AuthContext';
 import { fetchHeadlines } from '../utils/groqNews';
 
-export default function Header({ toggleDark }) {
+export default function Header({ toggleDark, onOpenSidebar }) {
   const navigate = useNavigate();
   const { logout } = useAuth();
   const { addNotification } = useNotifications();
@@ -42,6 +42,13 @@ export default function Header({ toggleDark }) {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-14">
         {/* Left group */}
         <div className="flex items-center gap-2">
+          <button
+            onClick={onOpenSidebar}
+            className="p-2 rounded-md md:hidden hover:bg-gray-100 dark:hover:bg-gray-700"
+            aria-label="Menu"
+          >
+            <Menu size={20} className="text-gray-600 dark:text-gray-100" />
+          </button>
           <Search size={20} className="text-gray-500 dark:text-gray-400" />
         </div>
 

--- a/src/components/MobileSidebar.jsx
+++ b/src/components/MobileSidebar.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+import Sidebar, { navItems } from './Sidebar';
+
+export default function MobileSidebar({ open, onClose }) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            className="fixed inset-0 bg-black/40 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+          <motion.aside
+            className="fixed left-0 top-0 h-full w-64 bg-white dark:bg-gray-950 z-50 shadow-lg flex flex-col"
+            initial={{ x: '-100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '-100%' }}
+            transition={{ type: 'spring', stiffness: 260, damping: 25 }}
+          >
+            <div className="p-4 flex items-center justify-between border-b border-gray-200 dark:border-gray-800">
+              <img src="/tek_logo.png" alt="Tek Afrika" className="h-8" />
+              <button
+                onClick={onClose}
+                className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+                aria-label="Fermer"
+              >
+                <X size={20} className="text-gray-700 dark:text-gray-300" />
+              </button>
+            </div>
+            <nav className="mt-4 space-y-1 flex-1 overflow-y-auto">
+              {navItems.map(({ to, label, icon: Icon }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  end
+                  onClick={onClose}
+                  className={({ isActive }) =>
+                    `flex items-center px-6 py-3 rounded-r-full transition text-sm ${
+                      isActive
+                        ? 'bg-brand-100 dark:bg-brand-800 text-brand-700 dark:text-brand-200'
+                        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+                    }`
+                  }
+                >
+                  <Icon className="mr-3 h-5 w-5" />
+                  {label}
+                </NavLink>
+              ))}
+            </nav>
+          </motion.aside>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { LayoutDashboard, Layers, FileText, Sparkles, Settings as SettingsIcon, Bell } from 'lucide-react';
+import {
+  LayoutDashboard,
+  Layers,
+  FileText,
+  Sparkles,
+  Settings as SettingsIcon,
+  Bell,
+} from 'lucide-react';
 
-const navItems = [
+export const navItems = [
   { to: '/', label: 'Tableau de bord', icon: LayoutDashboard },
   { to: '/strategic', label: 'Vue stratégique', icon: Layers },
   { to: '/content', label: 'Générateur de contenu', icon: FileText },


### PR DESCRIPTION
## Summary
- export sidebar navigation items
- add `MobileSidebar` component for small screens
- show menu button in the header
- update main container styling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68686fa1b27c83318a5a908627af4430