### PR TITLE
Ensure white text for generated output in dark mode

### DIFF
--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -68,7 +68,7 @@ export default function ContentGenerator() {
         {paragraphs.map((p, i) => (
           <li
             key={i}
-            className="bg-white dark:bg-gray-900 p-4 rounded shadow leading-relaxed"
+            className="bg-white dark:bg-gray-900 p-4 rounded shadow leading-relaxed dark:text-white"
           >
             {p}
           </li>

--- a/src/pages/TitleGenerator.jsx
+++ b/src/pages/TitleGenerator.jsx
@@ -60,7 +60,7 @@ export default function TitleGenerator() {
         className="space-y-2"
       >
         {titles.map((t) => (
-          <li key={t} className="bg-white dark:bg-gray-900 p-3 rounded shadow">
+          <li key={t} className="bg-white dark:bg-gray-900 p-3 rounded shadow dark:text-white">
             {t}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- adjust generated paragraphs to use white text in dark mode
- ensure generated titles also appear white when dark mode is active

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686917f74a188331bfcf35edc5a8d702