### PR TITLE
Add social share feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Le projet a été réalisé dans le cadre d’un **stage d’initiation de 3ᵉ 
 - 🎛️ **Filtres dynamiques** : par langue, période, catégorie, etc.
 - 🌗 **Mode sombre/claire** : bascule native avec mémorisation
 - 🚀 **Interface rapide & responsive** : conçue avec React, Vite et Tailwind CSS
+- 🔗 **Partage facile** : diffusion d'un article ou sujet tendance en un clic
 
 ---
 

--- a/src/components/NewsFeed.jsx
+++ b/src/components/NewsFeed.jsx
@@ -1,6 +1,8 @@
 
 import React, { useEffect, useState } from 'react';
 import { fetchNewsCards } from '../utils/groqNews';
+import { shareText } from '../utils/share';
+import { Share2 } from 'lucide-react';
 
 /**
  * Simple list of Moroccan news cards fetched from Groq API.
@@ -35,6 +37,15 @@ export default function NewsFeed({ count = 10 }) {
           {item.summary && (
             <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{item.summary}</p>
           )}
+          <div className="flex justify-end mt-2">
+            <button
+              onClick={() => shareText(item.title)}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager"
+            >
+              <Share2 size={16} />
+            </button>
+          </div>
         </li>
       ))}
     </ul>

--- a/src/components/TrendCard.jsx
+++ b/src/components/TrendCard.jsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { TrendingUp, TrendingDown } from 'lucide-react';
+import { TrendingUp, TrendingDown, Share2 } from 'lucide-react';
+import { shareText } from '../utils/share';
 
 /**
  * Small card showing a trending topic.
@@ -23,6 +24,15 @@ export default function TrendCard({ category, title, timeAgo, change }) {
           <Icon size={12} />
           {change}
         </span>
+      </div>
+      <div className="flex justify-end mt-2">
+        <button
+          onClick={() => shareText(`${title} (${category})`)}
+          className="text-gray-500 hover:text-brand-600"
+          aria-label="Partager"
+        >
+          <Share2 size={16} />
+        </button>
       </div>
     </div>
   );

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -1,0 +1,11 @@
+export function shareText(text) {
+  const url = window.location.href;
+  if (navigator.share) {
+    navigator.share({ title: 'SmartNews360', text, url }).catch((err) => {
+      console.error('share failed', err);
+    });
+  } else {
+    const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text + ' ' + url)}`;
+    window.open(shareUrl, '_blank');
+  }
+}


### PR DESCRIPTION
## Summary
- allow easy sharing via new `shareText` util
- add share buttons to Trend cards and News items
- document feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fdb546f588331a9cd750387b980b8