### PR TITLE
Add persistent category preferences

### DIFF
--- a/src/components/TrendingTopics.jsx
+++ b/src/components/TrendingTopics.jsx
@@ -3,12 +3,14 @@ import React, { useEffect, useState } from 'react';
 import TrendCard from './TrendCard';
 import { fetchTrendingTopics } from '../utils/groqNews';
 import { useFilterStore } from '../store';
+import { usePreferences } from '../context/PreferenceContext';
 
 export default function TrendingTopics({ count = 6 }) {
   const [topics, setTopics] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const { section } = useFilterStore();
+  const { categories } = usePreferences();
 
   useEffect(() => {
     fetchTrendingTopics(count)
@@ -18,7 +20,9 @@ export default function TrendingTopics({ count = 6 }) {
   }, [count]);
 
   const filtered = topics.filter(
-    (t) => section.size === 0 || section.has(t.category)
+    (t) =>
+      (section.size === 0 || section.has(t.category)) &&
+      (categories.size === 0 || categories.has(t.category))
   );
 
   if (loading) return <p>Chargement…</p>;

--- a/src/context/PreferenceContext.jsx
+++ b/src/context/PreferenceContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const PreferenceContext = createContext();
+export const usePreferences = () => useContext(PreferenceContext);
+
+const STORAGE_KEY = 'prefs.categories';
+
+export function PreferenceProvider({ children }) {
+  const [categories, setCategories] = useState(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+      return new Set(saved ?? []);
+    } catch {
+      return new Set();
+    }
+  });
+
+  const toggleCategory = (cat) => {
+    setCategories(prev => {
+      const next = new Set(prev);
+      next.has(cat) ? next.delete(cat) : next.add(cat);
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(categories)));
+  }, [categories]);
+
+  return (
+    <PreferenceContext.Provider value={{ categories, toggleCategory }}>
+      {children}
+    </PreferenceContext.Provider>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { ThemeProvider } from './context/ThemeContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
+import { PreferenceProvider } from './context/PreferenceContext';
 import App from './App';
 import Connexion from './pages/Connexion';
 import './index.css';
@@ -22,19 +23,21 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <ThemeProvider>
     <NotificationProvider>
     <AuthProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Connexion />} />
-          <Route
-            path="/*"
-            element={
-              <RequireAuth>
-                <App />
-              </RequireAuth>
-            }
-          />
-        </Routes>
-      </BrowserRouter>
+      <PreferenceProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/login" element={<Connexion />} />
+            <Route
+              path="/*"
+              element={
+                <RequireAuth>
+                  <App />
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </BrowserRouter>
+      </PreferenceProvider>
     </AuthProvider>
       </NotificationProvider>
   </ThemeProvider>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { useTheme } from '../context/ThemeContext';
+import { usePreferences } from '../context/PreferenceContext';
 
 export default function Settings() {
   const { dark, toggle: toggleDark } = useTheme();
   const [emailNotif, setCourrielNotif] = useState(true);
+  const { categories, toggleCategory } = usePreferences();
 
   return (
     <div className="flex justify-center pt-10 px-4">
@@ -36,6 +38,24 @@ export default function Settings() {
             />
             <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand rounded-full peer peer-checked:bg-brand peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 after:left-[4px] after:bg-white after:border after:rounded-full after:h-5 after:w-5 after:transition-all" />
           </label>
+        </div>
+
+        {/* Preferred categories */}
+        <div>
+          <span className="text-gray-700 dark:text-gray-300 block mb-2">Centres d'intérêt</span>
+          <div className="space-y-1">
+            {['Politique', 'Sport', 'Technologie'].map((cat) => (
+              <label key={cat} className="flex items-center space-x-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={categories.has(cat)}
+                  onChange={() => toggleCategory(cat)}
+                  className="text-brand focus:ring-brand"
+                />
+                <span className="text-gray-700 dark:text-gray-300">{cat}</span>
+              </label>
+            ))}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable persisting preferred categories
- filter topics by saved preferences
- expose category preferences in settings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fde0a63148331b98886d8ddda6edc