### PR TITLE
Add skeleton placeholders when loading

### DIFF
--- a/src/components/AIRecommendations.jsx
+++ b/src/components/AIRecommendations.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { fetchAIRecommendations } from '../utils/groqNews';
+import Skeleton from './ui/Skeleton';
 
 export default function AIRecommendations({ count = 3 }) {
   const [recs, setRecs] = useState([]);
@@ -15,7 +16,14 @@ export default function AIRecommendations({ count = 3 }) {
       .finally(() => setLoading(false));
   }, [count]);
 
-  if (loading) return <p>Chargement…</p>;
+  if (loading)
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: count }).map((_, idx) => (
+          <Skeleton key={idx} className="h-12" />
+        ))}
+      </div>
+    );
   if (error) return <p className="text-danger text-sm">Impossible de charger les recommandations.</p>;
 
   return (

--- a/src/components/NewsFeed.jsx
+++ b/src/components/NewsFeed.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { fetchNewsCards } from '../utils/groqNews';
 import { shareText } from '../utils/share';
 import { Share2 } from 'lucide-react';
+import Skeleton from './ui/Skeleton';
 
 /**
  * Simple list of Moroccan news cards fetched from Groq API.
@@ -23,7 +24,16 @@ export default function NewsFeed({ count = 10 }) {
       .finally(() => setLoading(false));
   }, [count]);
 
-  if (loading) return <p>Chargement…</p>;
+  if (loading)
+    return (
+      <ul className="space-y-4">
+        {Array.from({ length: count }).map((_, idx) => (
+          <li key={idx}>
+            <Skeleton className="h-20 w-full" />
+          </li>
+        ))}
+      </ul>
+    );
   if (error) return <p className="text-danger">Impossible de charger les actualités.</p>;
 
   return (

--- a/src/components/TrendingTopics.jsx
+++ b/src/components/TrendingTopics.jsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect, useState } from 'react';
 import TrendCard from './TrendCard';
+import Skeleton from './ui/Skeleton';
 import { fetchTrendingTopics } from '../utils/groqNews';
 import { useFilterStore } from '../store';
 import { usePreferences } from '../context/PreferenceContext';
@@ -25,7 +26,14 @@ export default function TrendingTopics({ count = 6 }) {
       (categories.size === 0 || categories.has(t.category))
   );
 
-  if (loading) return <p>Chargement…</p>;
+  if (loading)
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {Array.from({ length: count }).map((_, idx) => (
+          <Skeleton key={idx} className="h-24" />
+        ))}
+      </div>
+    );
   if (error) return <p className="text-danger text-sm">Impossible de charger les tendances.</p>;
 
   return (

--- a/src/components/ui/Skeleton.jsx
+++ b/src/components/ui/Skeleton.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default function Skeleton({ className = "" }) {
+  return (
+    <div className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className}`}></div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a simple `Skeleton` component with a pulse animation
- show skeletons in TrendingTopics, NewsFeed and AIRecommendations while loading

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ffc4707bc8331b25f0719ffd314f5