### PR TITLE
Add language selector and internationalize prompts

### DIFF
--- a/src/components/AIRecommendations.jsx
+++ b/src/components/AIRecommendations.jsx
@@ -2,19 +2,21 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { fetchAIRecommendations } from '../utils/groqNews';
+import { useLanguage } from '../context/LanguageContext';
 import Skeleton from './ui/Skeleton';
 
 export default function AIRecommendations({ count = 3 }) {
   const [recs, setRecs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const { lang } = useLanguage();
 
   useEffect(() => {
-    fetchAIRecommendations(count)
+    fetchAIRecommendations(count, lang)
       .then((data) => setRecs(data))
       .catch((e) => setError(e))
       .finally(() => setLoading(false));
-  }, [count]);
+  }, [count, lang]);
 
   if (loading)
     return (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,18 +5,20 @@ import { useNavigate } from 'react-router-dom';
 import { NotificationButton, useNotifications } from './notification-system';
 import { useAuth } from '../context/AuthContext';
 import { fetchHeadlines } from '../utils/groqNews';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function Header({ toggleDark, onOpenSidebar }) {
   const navigate = useNavigate();
   const { logout } = useAuth();
   const { addNotification } = useNotifications();
+  const { lang } = useLanguage();
 
   // Load headlines every 5 minutes and push as notifications
   useEffect(() => {
     let abort = false;
     const load = async () => {
       try {
-        const data = await fetchHeadlines(10);
+        const data = await fetchHeadlines(10, lang);
         if (!abort && Array.isArray(data)) {
           data.forEach((t) => addNotification({ title: t }));
         }
@@ -30,7 +32,7 @@ export default function Header({ toggleDark, onOpenSidebar }) {
       abort = true;
       clearInterval(id);
     };
-  }, [addNotification]);
+  }, [addNotification, lang]);
 
   const handleDéconnexion = () => {
     logout();

--- a/src/components/NewsFeed.jsx
+++ b/src/components/NewsFeed.jsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { fetchNewsCards } from '../utils/groqNews';
+import { useLanguage } from '../context/LanguageContext';
 import { shareText } from '../utils/share';
 import { Share2 } from 'lucide-react';
 import Skeleton from './ui/Skeleton';
@@ -13,16 +14,17 @@ export default function NewsFeed({ count = 10 }) {
   const [news, setNews] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
+  const { lang } = useLanguage();
 
   useEffect(() => {
-    fetchNewsCards(count)
+    fetchNewsCards(count, lang)
       .then((data) => setNews(data))
       .catch((err) => {
         console.error(err);
         setError(err);
       })
       .finally(() => setLoading(false));
-  }, [count]);
+  }, [count, lang]);
 
   if (loading)
     return (

--- a/src/components/TrendingTopics.jsx
+++ b/src/components/TrendingTopics.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import TrendCard from './TrendCard';
 import Skeleton from './ui/Skeleton';
 import { fetchTrendingTopics } from '../utils/groqNews';
+import { useLanguage } from '../context/LanguageContext';
 import { useFilterStore } from '../store';
 import { usePreferences } from '../context/PreferenceContext';
 
@@ -12,13 +13,14 @@ export default function TrendingTopics({ count = 6 }) {
   const [error, setError] = useState(null);
   const { section } = useFilterStore();
   const { categories } = usePreferences();
+  const { lang } = useLanguage();
 
   useEffect(() => {
-    fetchTrendingTopics(count)
+    fetchTrendingTopics(count, lang)
       .then((data) => setTopics(data))
       .catch((e) => setError(e))
       .finally(() => setLoading(false));
-  }, [count]);
+  }, [count, lang]);
 
   const filtered = topics.filter(
     (t) =>

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const LanguageContext = createContext();
+export const useLanguage = () => useContext(LanguageContext);
+
+const STORAGE_KEY = 'lang';
+
+export function LanguageProvider({ children }) {
+  const [lang, setLang] = useState(() => localStorage.getItem(STORAGE_KEY) || 'fr');
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, lang);
+  }, [lang]);
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { ThemeProvider } from './context/ThemeContext';
+import { LanguageProvider } from './context/LanguageContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { PreferenceProvider } from './context/PreferenceContext';
 import App from './App';
@@ -21,24 +22,26 @@ function RequireAuth({ children }) {
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <ThemeProvider>
-    <NotificationProvider>
-    <AuthProvider>
-      <PreferenceProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/login" element={<Connexion />} />
-            <Route
-              path="/*"
-              element={
-                <RequireAuth>
-                  <App />
-                </RequireAuth>
-              }
-            />
-          </Routes>
-        </BrowserRouter>
-      </PreferenceProvider>
-    </AuthProvider>
+    <LanguageProvider>
+      <NotificationProvider>
+        <AuthProvider>
+          <PreferenceProvider>
+            <BrowserRouter>
+              <Routes>
+                <Route path="/login" element={<Connexion />} />
+                <Route
+                  path="/*"
+                  element={
+                    <RequireAuth>
+                      <App />
+                    </RequireAuth>
+                  }
+                />
+              </Routes>
+            </BrowserRouter>
+          </PreferenceProvider>
+        </AuthProvider>
       </NotificationProvider>
+    </LanguageProvider>
   </ThemeProvider>
 );

--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { generateArticleContent } from '../utils/groqNews';
+import { useLanguage } from '../context/LanguageContext';
 import { Loader2 } from 'lucide-react';
 
 export default function ContentGenerator() {
@@ -9,13 +10,14 @@ export default function ContentGenerator() {
   const [count, setCount] = useState(4);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { lang } = useLanguage();
 
   const handleGenerate = async () => {
     if (!topic) return;
     setLoading(true);
     setError(null);
     try {
-      const res = await generateArticleContent(topic, count);
+      const res = await generateArticleContent(topic, count, lang);
       setParagraphs(res);
     } catch (e) {
       console.error(e);

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { useTheme } from '../context/ThemeContext';
 import { usePreferences } from '../context/PreferenceContext';
+import { useLanguage } from '../context/LanguageContext';
 
 export default function Settings() {
   const { dark, toggle: toggleDark } = useTheme();
   const [emailNotif, setCourrielNotif] = useState(true);
   const { categories, toggleCategory } = usePreferences();
+  const { lang, setLang } = useLanguage();
 
   return (
     <div className="flex justify-center pt-10 px-4">
@@ -24,6 +26,20 @@ export default function Settings() {
             />
             <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand rounded-full peer peer-checked:bg-brand peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-0.5 after:left-[4px] after:bg-white after:border after:rounded-full after:h-5 after:w-5 after:transition-all" />
           </label>
+        </div>
+
+        {/* Language selector */}
+        <div className="flex items-center justify-between">
+          <span className="text-gray-700 dark:text-gray-300">Langue</span>
+          <select
+            value={lang}
+            onChange={e => setLang(e.target.value)}
+            className="px-3 py-1 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+          >
+            <option value="fr">FR</option>
+            <option value="en">EN</option>
+            <option value="ar">AR</option>
+          </select>
         </div>
 
         {/* Courriel notifications */}

--- a/src/pages/TitleGenerator.jsx
+++ b/src/pages/TitleGenerator.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { generateArticleTitles } from '../utils/groqNews';
+import { useLanguage } from '../context/LanguageContext';
 
 /**
  * Page allowing users to generate catchy article titles via Groq’s Mixtral model.
@@ -12,6 +13,7 @@ export default function TitleGenerator() {
   const [titles, setTitles] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { lang } = useLanguage();
 
   const handleGenerate = async () => {
     const q = topic.trim();
@@ -19,7 +21,7 @@ export default function TitleGenerator() {
     setLoading(true);
     setError(null);
     try {
-      const res = await generateArticleTitles(q);
+      const res = await generateArticleTitles(q, 6, lang);
       if (!res || res.length === 0) {
         setError("Impossible de générer des titres pour le moment.");
       } else {


### PR DESCRIPTION
## Summary
- create `LanguageContext` to store language preference
- wrap app with `LanguageProvider`
- internationalize Groq helpers with `lang` parameter
- hook components into the new context
- add language selector to Settings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ffdd42df083318ddfeabaa404a443