### PR TITLE
Keep shimmer loader when recommendations fail

### DIFF
--- a/src/components/AIRecommendations.jsx
+++ b/src/components/AIRecommendations.jsx
@@ -18,7 +18,7 @@ export default function AIRecommendations({ count = 3 }) {
       .finally(() => setLoading(false));
   }, [count, lang]);
 
-  if (loading)
+  if (loading || error)
     return (
       <div className="space-y-3">
         {Array.from({ length: count }).map((_, idx) => (
@@ -26,7 +26,6 @@ export default function AIRecommendations({ count = 3 }) {
         ))}
       </div>
     );
-  if (error) return <p className="text-danger text-sm">Impossible de charger les recommandations.</p>;
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary
- show skeleton loader when recommendations fail to load

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68712969f8e883319fc328a67b0eaba6