### PR TITLE
Improve trending topics generation

### DIFF
--- a/src/components/TrendingTopics.jsx
+++ b/src/components/TrendingTopics.jsx
@@ -7,7 +7,8 @@ import { useLanguage } from '../context/LanguageContext';
 import { useFilterStore } from '../store';
 import { usePreferences } from '../context/PreferenceContext';
 
-export default function TrendingTopics({ count = 6 }) {
+export default function TrendingTopics({ count }) {
+  const num = count ?? Math.floor(Math.random() * 6) + 5; // 5 to 10
   const [topics, setTopics] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -16,11 +17,11 @@ export default function TrendingTopics({ count = 6 }) {
   const { lang } = useLanguage();
 
   useEffect(() => {
-    fetchTrendingTopics(count, lang)
+    fetchTrendingTopics(num, lang)
       .then((data) => setTopics(data))
       .catch((e) => setError(e))
       .finally(() => setLoading(false));
-  }, [count, lang]);
+  }, [num, lang]);
 
   const filtered = topics.filter(
     (t) =>
@@ -31,7 +32,7 @@ export default function TrendingTopics({ count = 6 }) {
   if (loading)
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {Array.from({ length: count }).map((_, idx) => (
+        {Array.from({ length: num }).map((_, idx) => (
           <Skeleton key={idx} className="h-24" />
         ))}
       </div>

--- a/src/utils/groqNews.js
+++ b/src/utils/groqNews.js
@@ -135,7 +135,7 @@ export async function fetchTrendingTopics(count = 6, lang = 'fr') {
     messages: [
       {
         role: 'system',
-        content: `Generate a JSON array of ${count} objects with keys 'category', 'title', 'timeAgo', 'change'. Categories in ${name(lang)} (Sport, Politique, Technologie, etc.). 'change' with + or - percentage.`,
+        content: `You are an expert Moroccan news curator summarizing real trending topics from trusted media sources. Reply in ${name(lang)} with a JSON array of exactly ${count} objects using the keys 'category', 'title', 'timeAgo' and 'change'. Categories should be in ${name(lang)} (e.g. Sport, Politique, Technologie). Ensure topics reflect what is currently popular and avoid invented stories. The 'change' value must contain a +/- percentage.`,
       },
       { role: 'user', content: tr({ fr: 'Donne-moi les tendances actuelles.', en: 'Give me the current trends.', ar: 'ما هي المواضيع الرائجة حالياً؟' }, lang) },
     ],


### PR DESCRIPTION
## Summary
- randomize number of trending topics between 5 and 10
- refine Groq prompt for more accurate trending news

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874d3aafa148331b999f3afe17adc0d