### PR TITLE
Fix trending topics fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ VITE_GROQ_KEY=sk-xxxxxxxxxxxxxxxxxxxx
 VITE_NEWSAPI_KEY=42ae7764f4364cd792a3eda2a1b77343
 ```
 
+Si `VITE_NEWSAPI_KEY` n'est pas fourni ou que la requête à NewsAPI échoue,
+l'application utilisera automatiquement la génération IA pour afficher les
+sujets tendance.
+
 🧠 Aperçu IA (Llama 3 via Groq)
 
 ```js


### PR DESCRIPTION
## Summary
- fallback to AI generated trending topics when NewsAPI fails
- mention fallback behavior in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874dacfc0d08331b00b88b96382d2dc