### PR TITLE
Add GNews news cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
 dist/
+.env

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Le projet a été réalisé dans le cadre d’un **stage d’initiation de 3ᵉ 
 | Tailwind CSS  | Design UI moderne et responsive       |
 | Zustand       | Gestion légère de l'état              |
 | Groq API      | Génération de contenu IA (Llama 3)    |
+| GNews API     | Actualités avec images en français     |
 | Netlify/Vercel| Déploiement statique                  |
 
 ---
@@ -50,6 +51,7 @@ npm run dev
 ```env
 VITE_GROQ_KEY=sk-xxxxxxxxxxxxxxxxxxxx
 VITE_NEWSAPI_KEY=42ae7764f4364cd792a3eda2a1b77343
+VITE_GNEWS_KEY=140c29519a8b267bda2474ccbd8b0f02
 ```
 
 🧠 Aperçu IA (Llama 3 via Groq)

--- a/src/components/GNewsFeed.jsx
+++ b/src/components/GNewsFeed.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import Skeleton from './ui/Skeleton';
+import { fetchGNewsArticles } from '../utils/gnewsApi';
+
+export default function GNewsFeed({ count = 6 }) {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchGNewsArticles(count, 'fr')
+      .then(setArticles)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, [count]);
+
+  if (loading)
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {Array.from({ length: count }).map((_, i) => (
+          <Skeleton key={i} className="h-40" />
+        ))}
+      </div>
+    );
+
+  if (error) return <p className="text-danger text-sm">Impossible de charger les nouvelles.</p>;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {articles.map((a, idx) => (
+        <a
+          key={idx}
+          href={a.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900"
+        >
+          {a.image && (
+            <img
+              src={a.image}
+              alt=""
+              className="w-full h-40 object-cover group-hover:scale-105 transition"
+            />
+          )}
+          <div className="p-4 space-y-1">
+            <h3 className="font-semibold text-gray-800 dark:text-gray-100 leading-snug">
+              {a.title}
+            </h3>
+            {a.description && (
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {a.description}
+              </p>
+            )}
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import TrendingTopics from '../components/TrendingTopics';
 import SportsHighlights from '../components/SportsHighlights';
 import AIRecommendations from '../components/AIRecommendations';
 import NewsFeed from '../components/NewsFeed';
+import GNewsFeed from '../components/GNewsFeed';
 
 export default function Dashboard() {
   return (
@@ -32,6 +33,12 @@ export default function Dashboard() {
         Actualités Maroc
       </h2>
       <NewsFeed count={10} />
+    </div>
+    <div>
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+        Dernières nouvelles (GNews)
+      </h2>
+      <GNewsFeed count={6} />
     </div>
   </div>
 </section>

--- a/src/utils/gnewsApi.js
+++ b/src/utils/gnewsApi.js
@@ -1,0 +1,17 @@
+export async function fetchGNewsArticles(count = 10, lang = 'fr') {
+  const apiKey = import.meta.env.VITE_GNEWS_KEY;
+  if (!apiKey) throw new Error('VITE_GNEWS_KEY not set');
+  const url = `https://gnews.io/api/v4/top-headlines?lang=${lang}&token=${apiKey}&max=${count}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GNews error ${res.status}`);
+  const json = await res.json();
+  const articles = json.articles || [];
+  return articles.slice(0, count).map((a) => ({
+    title: a.title,
+    description: a.description,
+    image: a.image,
+    url: a.url,
+    publishedAt: a.publishedAt,
+    source: a.source?.name || ''
+  }));
+}


### PR DESCRIPTION
## Summary
- integrate GNews API
- show French news with images
- document new `VITE_GNEWS_KEY` in README
- display GNews feed on dashboard
- ignore `.env` files

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874db9f7a9483319f8ee1d50438ec7a