### PR TITLE
Use Mediastack for tech news feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Le projet a été réalisé dans le cadre d’un **stage d’initiation de 3ᵉ 
 | Zustand       | Gestion légère de l'état              |
 | Groq API      | Génération de contenu IA (Llama 3)    |
 | GNews API     | Actualités avec images en français     |
+| Mediastack API| Technologie mondiale en français       |
 | Netlify/Vercel| Déploiement statique                  |
 
 ---
@@ -50,13 +51,11 @@ npm run dev
 
 ```env
 VITE_GROQ_KEY=sk-xxxxxxxxxxxxxxxxxxxx
-VITE_NEWSAPI_KEY=42ae7764f4364cd792a3eda2a1b77343
 VITE_GNEWS_KEY=140c29519a8b267bda2474ccbd8b0f02
+VITE_MEDIASTACK_KEY=32f46c615a63368d99acc3b5b728fbfb
 ```
 
-Si `VITE_NEWSAPI_KEY` n'est pas fourni ou que la requête à NewsAPI échoue,
-l'application utilisera automatiquement la génération IA pour afficher les
-sujets tendance.
+La clé `VITE_MEDIASTACK_KEY` permet d'afficher les actualités technologiques mondiales.
 
 🧠 Aperçu IA (Llama 3 via Groq)
 

--- a/src/components/MediastackFeed.jsx
+++ b/src/components/MediastackFeed.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import Skeleton from './ui/Skeleton';
+import { fetchTechNews } from '../utils/mediastackApi';
+
+export default function MediastackFeed({ count = 6 }) {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchTechNews(count)
+      .then(setArticles)
+      .catch((err) => {
+        console.error(err);
+        setError(err);
+      })
+      .finally(() => setLoading(false));
+  }, [count]);
+
+  if (loading)
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {Array.from({ length: count }).map((_, i) => (
+          <Skeleton key={i} className="h-40" />
+        ))}
+      </div>
+    );
+
+  if (error) return <p className="text-danger text-sm">Impossible de charger les nouvelles.</p>;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {articles.map((a, idx) => (
+        <a
+          key={idx}
+          href={a.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900"
+        >
+          {a.image && (
+            <img
+              src={a.image}
+              alt=""
+              className="w-full h-40 object-cover group-hover:scale-105 transition"
+            />
+          )}
+          <div className="p-4 space-y-1">
+            <h3 className="font-semibold text-gray-800 dark:text-gray-100 leading-snug">
+              {a.title}
+            </h3>
+            {a.description && (
+              <p className="text-sm text-gray-600 dark:text-gray-300">{a.description}</p>
+            )}
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
-import Stats from '../components/Stats';
-import TrendingTopics from '../components/TrendingTopics';
+import MediastackFeed from '../components/MediastackFeed';
 import SportsHighlights from '../components/SportsHighlights';
 import AIRecommendations from '../components/AIRecommendations';
 import NewsFeed from '../components/NewsFeed';
@@ -15,9 +14,9 @@ export default function Dashboard() {
   <div className="space-y-6">
     <div>
       <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-        Sujets tendance
+        Actualités technologie (Monde)
       </h2>
-      <TrendingTopics />
+      <MediastackFeed />
     </div>
     <div>
       <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">

--- a/src/utils/mediastackApi.js
+++ b/src/utils/mediastackApi.js
@@ -1,0 +1,17 @@
+export async function fetchTechNews(count = 6) {
+  const apiKey = import.meta.env.VITE_MEDIASTACK_KEY;
+  if (!apiKey) throw new Error('VITE_MEDIASTACK_KEY not set');
+  const url = `http://api.mediastack.com/v1/news?access_key=${apiKey}&languages=fr&categories=technology&sort=published_desc&limit=${count}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Mediastack error ${res.status}`);
+  const json = await res.json();
+  const articles = json.data || [];
+  return articles.map((a) => ({
+    title: a.title,
+    description: a.description,
+    image: a.image,
+    url: a.url,
+    source: a.source,
+    published_at: a.published_at,
+  }));
+}


### PR DESCRIPTION
## Summary
- replace Trending Topics with a new tech news feed
- fetch technology news from Mediastack in French
- document new Mediastack API key

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874debd42388331bbfbb1d902a1ebd1