### PR TITLE
Improve Mediastack feed handling of missing images

### DIFF
--- a/src/components/MediastackFeed.jsx
+++ b/src/components/MediastackFeed.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Skeleton from './ui/Skeleton';
 import { fetchTechNews } from '../utils/mediastackApi';
 import { sanitize } from '../utils/sanitize';
+import { truncate } from '../utils/truncate';
 
 export default function MediastackFeed({ count = 6 }) {
   const [articles, setArticles] = useState([]);
@@ -39,17 +40,21 @@ export default function MediastackFeed({ count = 6 }) {
           rel="noopener noreferrer"
           className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900"
         >
-          <img
-            src={a.image || '/tek_logo.png'}
-            alt=""
-            className="w-full h-40 object-cover group-hover:scale-105 transition"
-          />
+          {a.image && (
+            <img
+              src={a.image}
+              alt=""
+              className="w-full h-40 object-cover group-hover:scale-105 transition"
+            />
+          )}
           <div className="p-4 space-y-1">
             <h3 className="font-semibold text-gray-800 dark:text-gray-100 leading-snug">
-              {sanitize(a.title)}
+              {truncate(sanitize(a.title), 100)}
             </h3>
             {a.description && (
-              <p className="text-sm text-gray-600 dark:text-gray-300">{sanitize(a.description)}</p>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {truncate(sanitize(a.description), 120)}
+              </p>
             )}
           </div>
         </a>

--- a/src/utils/truncate.js
+++ b/src/utils/truncate.js
@@ -1,0 +1,5 @@
+export function truncate(text = '', max = 100) {
+  if (!text) return '';
+  const clean = text.toString();
+  return clean.length > max ? clean.slice(0, max).trimEnd() + '...' : clean;
+}


### PR DESCRIPTION
## Summary
- add helper to truncate text with ellipsis
- hide placeholder images if Mediastack article lacks media
- shorten Mediastack article titles and descriptions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874e75fb72083318052e2bdb99fb31d