### PR TITLE
Add social media sharing

### DIFF
--- a/src/components/ArticleDialog.jsx
+++ b/src/components/ArticleDialog.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Download } from 'lucide-react';
+import { X, Download, Twitter, Facebook, Linkedin } from 'lucide-react';
+import WordpressIcon from './icons/WordpressIcon';
+import { shareTo } from '../utils/share';
 
 export default function ArticleDialog({ open, item, onClose }) {
   const [keywords, setKeywords] = useState('');
@@ -76,7 +78,37 @@ export default function ArticleDialog({ open, item, onClose }) {
                   className="w-full p-2 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-800 dark:text-gray-100 outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
-              <div className="flex justify-end gap-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => shareTo('twitter', item.title)}
+                    className="text-gray-500 hover:text-brand-600"
+                    aria-label="Partager sur Twitter"
+                  >
+                    <Twitter size={16} />
+                  </button>
+                  <button
+                    onClick={() => shareTo('facebook', item.title)}
+                    className="text-gray-500 hover:text-brand-600"
+                    aria-label="Partager sur Facebook"
+                  >
+                    <Facebook size={16} />
+                  </button>
+                  <button
+                    onClick={() => shareTo('linkedin', item.title)}
+                    className="text-gray-500 hover:text-brand-600"
+                    aria-label="Partager sur LinkedIn"
+                  >
+                    <Linkedin size={16} />
+                  </button>
+                  <button
+                    onClick={() => shareTo('wordpress', item.title)}
+                    className="text-gray-500 hover:text-brand-600"
+                    aria-label="Partager sur WordPress"
+                  >
+                    <WordpressIcon size={16} />
+                  </button>
+                </div>
                 <button
                   onClick={handleDownload}
                   className="flex items-center gap-1 px-3 py-1.5 rounded bg-brand-600 text-white hover:bg-brand-700 text-sm"

--- a/src/components/icons/WordpressIcon.jsx
+++ b/src/components/icons/WordpressIcon.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function WordpressIcon({ size = 16, ...props }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" fill="none" />
+      <path d="M8 7h1.8l2.2 6.2L14.2 7h1.8l-3.4 9h-1.2L8 7z" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -9,3 +9,26 @@ export function shareText(text) {
     window.open(shareUrl, '_blank');
   }
 }
+
+export function shareTo(platform, text) {
+  const url = window.location.href;
+  const encodedText = encodeURIComponent(text);
+  const encodedUrl = encodeURIComponent(url);
+  let shareUrl = '';
+  switch (platform) {
+    case 'facebook':
+      shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedText}`;
+      break;
+    case 'linkedin':
+      shareUrl = `https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedText}`;
+      break;
+    case 'wordpress':
+      shareUrl = `https://wordpress.com/wp-admin/press-this.php?u=${encodedUrl}&t=${encodedText}`;
+      break;
+    case 'twitter':
+    default:
+      shareUrl = `https://twitter.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`;
+      break;
+  }
+  window.open(shareUrl, '_blank');
+}


### PR DESCRIPTION
## Summary
- add per-platform sharing utility
- show share icons in article dialog
- include a simple WordPress icon

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68760ef7d1c08331ad8cda04ce0d6581