### PR TITLE
Enable article sharing on social feeds

### DIFF
--- a/src/components/GNewsFeed.jsx
+++ b/src/components/GNewsFeed.jsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from 'react';
 import Skeleton from './ui/Skeleton';
 import { fetchGNewsArticles } from '../utils/gnewsApi';
 import { sanitize } from '../utils/sanitize';
+import { shareTo } from '../utils/share';
+import { Twitter, Facebook, Linkedin } from 'lucide-react';
+import WordpressIcon from './icons/WordpressIcon';
 
 export default function GNewsFeed({ count = 6 }) {
   const [articles, setArticles] = useState([]);
@@ -50,6 +53,52 @@ export default function GNewsFeed({ count = 6 }) {
                 {sanitize(a.description)}
               </p>
             )}
+          </div>
+          <div className="px-4 pb-4 flex gap-2">
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('twitter', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur Twitter"
+            >
+              <Twitter size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('facebook', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur Facebook"
+            >
+              <Facebook size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('linkedin', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur LinkedIn"
+            >
+              <Linkedin size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('wordpress', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur WordPress"
+            >
+              <WordpressIcon size={16} />
+            </button>
           </div>
         </a>
       ))}

--- a/src/components/MediastackFeed.jsx
+++ b/src/components/MediastackFeed.jsx
@@ -3,6 +3,9 @@ import Skeleton from './ui/Skeleton';
 import { fetchTechNews } from '../utils/mediastackApi';
 import { sanitize } from '../utils/sanitize';
 import { truncate } from '../utils/truncate';
+import { shareTo } from '../utils/share';
+import { Twitter, Facebook, Linkedin } from 'lucide-react';
+import WordpressIcon from './icons/WordpressIcon';
 
 export default function MediastackFeed({ count = 6 }) {
   const [articles, setArticles] = useState([]);
@@ -56,6 +59,52 @@ export default function MediastackFeed({ count = 6 }) {
                 {truncate(sanitize(a.description), 120)}
               </p>
             )}
+          </div>
+          <div className="px-4 pb-4 flex gap-2">
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('twitter', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur Twitter"
+            >
+              <Twitter size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('facebook', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur Facebook"
+            >
+              <Facebook size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('linkedin', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur LinkedIn"
+            >
+              <Linkedin size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('wordpress', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur WordPress"
+            >
+              <WordpressIcon size={16} />
+            </button>
           </div>
         </a>
       ))}

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -10,8 +10,7 @@ export function shareText(text) {
   }
 }
 
-export function shareTo(platform, text) {
-  const url = window.location.href;
+export function shareTo(platform, text, url = window.location.href) {
   const encodedText = encodeURIComponent(text);
   const encodedUrl = encodeURIComponent(url);
   let shareUrl = '';


### PR DESCRIPTION
## Summary
- enhance `shareTo` helper with optional URL argument
- add share buttons to Mediastack technology news cards
- add the same sharing options to GNews feed cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876149a29708331bd8c055aaaa795ec