### PR TITLE
Use Google News RSS instead of AI recommendations

### DIFF
--- a/api/googleNewsRss.js
+++ b/api/googleNewsRss.js
@@ -1,0 +1,16 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const { q = '' } = req.query;
+  const url = `https://news.google.com/rss/search?q=${encodeURIComponent(q)}&hl=fr&gl=FR&ceid=FR:fr`;
+  try {
+    const response = await fetch(url);
+    const text = await response.text();
+    res.status(response.status).send(text);
+  } catch (err) {
+    console.error('Google RSS proxy error:', err);
+    res.status(500).json({ error: 'Proxy error', details: err.message });
+  }
+}

--- a/src/components/GoogleRssFeed.jsx
+++ b/src/components/GoogleRssFeed.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from 'react';
+import Skeleton from './ui/Skeleton';
+import { fetchTechKeywords } from '../utils/groqNews';
+import { fetchGoogleRssArticles } from '../utils/googleRss';
+import { sanitize } from '../utils/sanitize';
+import { shareTo } from '../utils/share';
+import { Twitter, Facebook, Linkedin } from 'lucide-react';
+import WordpressIcon from './icons/WordpressIcon';
+import { useLanguage } from '../context/LanguageContext';
+
+export default function GoogleRssFeed({ count = 6 }) {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const { lang } = useLanguage();
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const keywords = await fetchTechKeywords(5, lang);
+        const query = keywords.join(' OR ');
+        const data = await fetchGoogleRssArticles(query, count);
+        if (!cancelled) setArticles(data);
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) setError(e);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [count, lang]);
+
+  if (loading)
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {Array.from({ length: count }).map((_, i) => (
+          <Skeleton key={i} className="h-40" />
+        ))}
+      </div>
+    );
+
+  if (error) return <p className="text-danger text-sm">Impossible de charger les nouvelles.</p>;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {articles.map((a, idx) => (
+        <a
+          key={idx}
+          href={a.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900"
+        >
+          {a.image && (
+            <img
+              src={a.image}
+              alt=""
+              className="w-full h-40 object-cover group-hover:scale-105 transition"
+            />
+          )}
+          <div className="p-4 space-y-1">
+            <h3 className="font-semibold text-gray-800 dark:text-gray-100 leading-snug">
+              {sanitize(a.title)}
+            </h3>
+            {a.description && (
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {sanitize(a.description)}
+              </p>
+            )}
+          </div>
+          <div className="px-4 pb-4 flex gap-2">
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('twitter', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur Twitter"
+            >
+              <Twitter size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('facebook', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur Facebook"
+            >
+              <Facebook size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('linkedin', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur LinkedIn"
+            >
+              <Linkedin size={16} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                shareTo('wordpress', a.title, a.url);
+              }}
+              className="text-gray-500 hover:text-brand-600"
+              aria-label="Partager sur WordPress"
+            >
+              <WordpressIcon size={16} />
+            </button>
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,9 +1,9 @@
 
 import React from 'react';
 import MediastackFeed from '../components/MediastackFeed';
-import AIRecommendations from '../components/AIRecommendations';
 import NewsFeed from '../components/NewsFeed';
 import GNewsFeed from '../components/GNewsFeed';
+import GoogleRssFeed from '../components/GoogleRssFeed';
 
 export default function Dashboard() {
   return (
@@ -19,9 +19,9 @@ export default function Dashboard() {
     </div>
     <div>
       <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-        Recommandations IA
+        Google News (RSS)
       </h2>
-      <AIRecommendations />
+      <GoogleRssFeed />
     </div>
   </div>
   <div className="space-y-6">

--- a/src/utils/googleRss.js
+++ b/src/utils/googleRss.js
@@ -1,0 +1,18 @@
+export async function fetchGoogleRssArticles(query, count = 6) {
+  const url = `/api/googleNewsRss?q=${encodeURIComponent(query)}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Google RSS error ${res.status}`);
+  const xml = await res.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, 'text/xml');
+  const items = Array.from(doc.querySelectorAll('item'));
+  return items.slice(0, count).map((item) => ({
+    title: item.querySelector('title')?.textContent || '',
+    description: item.querySelector('description')?.textContent || '',
+    url: item.querySelector('link')?.textContent || '',
+    image:
+      item.querySelector('media\\:content')?.getAttribute('url') ||
+      item.querySelector('enclosure')?.getAttribute('url') || '',
+    publishedAt: item.querySelector('pubDate')?.textContent || '',
+  }));
+}

--- a/src/utils/groqNews.js
+++ b/src/utils/groqNews.js
@@ -252,3 +252,34 @@ export async function chatCompletion(messages, options = {}) {
   const json = await groqRequest({ messages, ...options });
   return json.choices?.[0]?.message?.content ?? '';
 }
+
+/**
+ * Generate a list of technology keywords.
+ * @param {number} count
+ * @returns {Promise<string[]>}
+ */
+export async function fetchTechKeywords(count = 5, lang = 'fr') {
+  const prompts = {
+    user: {
+      fr: 'Donne-moi des mots-clés technologiques.',
+      en: 'Give me technology keywords.',
+      ar: 'أعطني كلمات مفتاحية في مجال التكنولوجيا.'
+    }
+  };
+  const json = await groqRequest({
+    messages: [
+      {
+        role: 'system',
+        content: `Return exactly ${count} ${name(lang)} technology keywords separated by commas.`,
+      },
+      { role: 'user', content: tr(prompts.user, lang) },
+    ],
+    max_tokens: 60,
+  });
+  const raw = json.choices?.[0]?.message?.content ?? '';
+  return raw
+    .split(/[,,\n]/)
+    .map(k => k.trim())
+    .filter(Boolean)
+    .slice(0, count);
+}


### PR DESCRIPTION
## Summary
- swap out the AI recommendations section with a Google News RSS feed
- create a new API route to proxy Google News RSS
- parse RSS in the frontend and display articles with share icons
- generate technology keywords through Groq to query Google News

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687616357c348331a7857ee62be04f41