### PR TITLE
Enable article-driven content generation

### DIFF
--- a/src/components/NewsFeed.jsx
+++ b/src/components/NewsFeed.jsx
@@ -4,8 +4,8 @@ import { fetchNewsCards } from '../utils/groqNews';
 import { useLanguage } from '../context/LanguageContext';
 import { shareText } from '../utils/share';
 import { Share2 } from 'lucide-react';
-import ArticleDialog from './ArticleDialog';
 import Skeleton from './ui/Skeleton';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Simple list of Moroccan news cards fetched from Groq API.
@@ -15,8 +15,8 @@ export default function NewsFeed({ count = 10 }) {
   const [news, setNews] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [selected, setSelected] = useState(null);
   const { lang } = useLanguage();
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchNewsCards(count, lang)
@@ -46,7 +46,7 @@ export default function NewsFeed({ count = 10 }) {
         {news.map((item, idx) => (
           <li
             key={idx}
-            onClick={() => setSelected(item)}
+            onClick={() => navigate('/content', { state: { topic: item.title } })}
             className="p-4 rounded-xl shadow bg-white dark:bg-gray-800 transition hover:shadow-lg cursor-pointer"
           >
             <h3 className="font-medium text-gray-900 dark:text-gray-100">{item.title}</h3>
@@ -65,7 +65,6 @@ export default function NewsFeed({ count = 10 }) {
           </li>
         ))}
       </ul>
-      <ArticleDialog open={!!selected} item={selected} onClose={() => setSelected(null)} />
     </>
   );
 }

--- a/src/utils/groqNews.js
+++ b/src/utils/groqNews.js
@@ -226,7 +226,7 @@ export async function generateArticleContent(topic, sections = 4, lang = 'fr') {
     messages: [
       {
         role: 'system',
-        content: `You are an experienced Moroccan journalist. Write exactly ${sections} coherent paragraphs (100–140 words each) in ${name(lang)}, rich in facts and magazine style, no headings or bullet points.`,
+        content: `You are an experienced Moroccan journalist acting as a senior content writer. Write exactly ${sections} coherent paragraphs (100–140 words each) in ${name(lang)}, rich in facts and magazine style, no headings or bullet points.`,
       },
       { role: 'user', content: topic.trim() },
     ],


### PR DESCRIPTION
## Summary
- update the article generation prompt to act as a senior content writer
- redirect news cards to the content generator with the selected title
- auto-fill the generator with the title and generate on arrival
- highlight extracted SEO keywords and show sharing/copy/download buttons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68761bb9ba1883318b8a07add8ef33ea