### PR TITLE
Add infinite feed

### DIFF
--- a/api/mediastack.js
+++ b/api/mediastack.js
@@ -8,8 +8,8 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'MEDIASTACK_KEY env variable not set' });
   }
 
-  const { count = 6 } = req.query;
-  const url = `http://api.mediastack.com/v1/news?access_key=${apiKey}&languages=fr&categories=technology&sort=published_desc&limit=${count}`;
+  const { count = 6, offset = 0 } = req.query;
+  const url = `http://api.mediastack.com/v1/news?access_key=${apiKey}&languages=fr&categories=technology&sort=published_desc&limit=${count}&offset=${offset}`;
 
   try {
     const response = await fetch(url);

--- a/src/components/InfiniteNewsFeed.jsx
+++ b/src/components/InfiniteNewsFeed.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import Skeleton from './ui/Skeleton';
+import { fetchGNewsArticles } from '../utils/gnewsApi';
+import { sanitize } from '../utils/sanitize';
+import { shareTo } from '../utils/share';
+import { Twitter, Facebook, Linkedin } from 'lucide-react';
+import WordpressIcon from './icons/WordpressIcon';
+import { useNavigate } from 'react-router-dom';
+
+export default function InfiniteNewsFeed({ batchSize = 6 }) {
+  const [articles, setArticles] = useState([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const loader = useRef(null);
+  const navigate = useNavigate();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchGNewsArticles(batchSize, 'fr', page);
+      setArticles((prev) => [...prev, ...data]);
+    } catch (e) {
+      console.error(e);
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
+  }, [batchSize, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setPage((p) => p + 1);
+      }
+    });
+    if (loader.current) observer.observe(loader.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {articles.map((a, idx) => (
+          <div
+            key={idx}
+            onClick={() => navigate('/titles', { state: { topic: sanitize(a.title) } })}
+            className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900 cursor-pointer"
+          >
+            <img
+              src={a.image || '/tek_logo.png'}
+              alt=""
+              className="w-full h-40 object-cover group-hover:scale-105 transition"
+            />
+            <div className="p-4 space-y-1">
+              <h3 className="font-semibold text-gray-800 dark:text-gray-100 leading-snug">
+                {sanitize(a.title)}
+              </h3>
+              {a.description && (
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                  {sanitize(a.description)}
+                </p>
+              )}
+            </div>
+            <div className="px-4 pb-4 flex gap-2">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  shareTo('twitter', a.title, a.url);
+                }}
+                className="text-gray-500 hover:text-brand-600"
+                aria-label="Partager sur Twitter"
+              >
+                <Twitter size={16} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  shareTo('facebook', a.title, a.url);
+                }}
+                className="text-gray-500 hover:text-brand-600"
+                aria-label="Partager sur Facebook"
+              >
+                <Facebook size={16} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  shareTo('linkedin', a.title, a.url);
+                }}
+                className="text-gray-500 hover:text-brand-600"
+                aria-label="Partager sur LinkedIn"
+              >
+                <Linkedin size={16} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  shareTo('wordpress', a.title, a.url);
+                }}
+                className="text-gray-500 hover:text-brand-600"
+                aria-label="Partager sur WordPress"
+              >
+                <WordpressIcon size={16} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {loading && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {Array.from({ length: batchSize }).map((_, i) => (
+            <Skeleton key={i} className="h-40" />
+          ))}
+        </div>
+      )}
+      {error && <p className="text-danger text-sm">Impossible de charger les nouvelles.</p>}
+      {/* Sentinel element */}
+      <div ref={loader}></div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,13 +3,14 @@ import React, { useMemo } from 'react';
 import MediastackFeed from '../components/MediastackFeed';
 import NewsFeed from '../components/NewsFeed';
 import GNewsFeed from '../components/GNewsFeed';
+import InfiniteNewsFeed from '../components/InfiniteNewsFeed';
 import GoogleRssFeed from '../components/GoogleRssFeed';
 
 export default function Dashboard() {
   const googleCount = useMemo(() => Math.floor(Math.random() * 5) + 6, []);
   return (
     <div className="space-y-6">
-      
+
       <section className="grid grid-cols-1 xl:grid-cols-2 gap-6">
   <div className="space-y-6">
     <div>
@@ -40,6 +41,12 @@ export default function Dashboard() {
     </div>
   </div>
 </section>
+      <div>
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+          Flux infini (GNews)
+        </h2>
+        <InfiniteNewsFeed batchSize={6} />
+      </div>
     </div>
   );
 }

--- a/src/utils/gnewsApi.js
+++ b/src/utils/gnewsApi.js
@@ -1,7 +1,7 @@
-export async function fetchGNewsArticles(count = 10, lang = 'fr') {
+export async function fetchGNewsArticles(count = 10, lang = 'fr', page = 1) {
   const apiKey = import.meta.env.VITE_GNEWS_KEY;
   if (!apiKey) throw new Error('VITE_GNEWS_KEY not set');
-  const url = `https://gnews.io/api/v4/top-headlines?lang=${lang}&token=${apiKey}&max=${count}`;
+  const url = `https://gnews.io/api/v4/top-headlines?lang=${lang}&token=${apiKey}&max=${count}&page=${page}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`GNews error ${res.status}`);
   const json = await res.json();

--- a/src/utils/mediastackApi.js
+++ b/src/utils/mediastackApi.js
@@ -1,5 +1,6 @@
-export async function fetchTechNews(count = 6) {
-  const url = `/api/mediastack?count=${count}`;
+export async function fetchTechNews(count = 6, page = 1) {
+  const offset = (page - 1) * count;
+  const url = `/api/mediastack?count=${count}&offset=${offset}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Mediastack error ${res.status}`);
   const json = await res.json();


### PR DESCRIPTION
## Summary
- update API fetchers to support paging
- update Mediastack API proxy
- create `InfiniteNewsFeed` component for endless article loading
- show infinite GNews feed on dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68762459ef9c833182418edf1f731910