### PR TITLE
Add AI tech news feed with dates

### DIFF
--- a/src/components/AITechNewsFeed.jsx
+++ b/src/components/AITechNewsFeed.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAITechNews } from '../utils/groqNews';
+import Skeleton from './ui/Skeleton';
+import { useLanguage } from '../context/LanguageContext';
+
+export default function AITechNewsFeed({ count = 10 }) {
+  const [news, setNews] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const { lang } = useLanguage();
+
+  useEffect(() => {
+    fetchAITechNews(count, lang)
+      .then(setNews)
+      .catch((e) => setError(e))
+      .finally(() => setLoading(false));
+  }, [count, lang]);
+
+  if (loading)
+    return (
+      <ul className="space-y-4">
+        {Array.from({ length: count }).map((_, idx) => (
+          <li key={idx}>
+            <Skeleton className="h-20 w-full" />
+          </li>
+        ))}
+      </ul>
+    );
+
+  if (error)
+    return <p className="text-danger text-sm">Impossible de charger les nouvelles.</p>;
+
+  return (
+    <ul className="space-y-4">
+      {news.map((item, idx) => (
+        <li key={idx} className="p-4 rounded-xl shadow bg-white dark:bg-gray-800">
+          <h3 className="font-medium text-gray-900 dark:text-gray-100">{item.title}</h3>
+          {item.summary && (
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{item.summary}</p>
+          )}
+          {item.date && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {new Date(item.date).toLocaleDateString()}
+            </p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/GNewsFeed.jsx
+++ b/src/components/GNewsFeed.jsx
@@ -53,6 +53,11 @@ export default function GNewsFeed({ count = 6 }) {
                 {sanitize(a.description)}
               </p>
             )}
+            {a.publishedAt && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {new Date(a.publishedAt).toLocaleDateString()}
+              </p>
+            )}
           </div>
           <div className="px-4 pb-4 flex gap-2">
             <button

--- a/src/components/GoogleRssFeed.jsx
+++ b/src/components/GoogleRssFeed.jsx
@@ -78,6 +78,11 @@ export default function GoogleRssFeed({ count = 6 }) {
                 {sanitize(a.description)}
               </p>
             )}
+            {a.publishedAt && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {new Date(a.publishedAt).toLocaleDateString()}
+              </p>
+            )}
           </div>
           <div className="px-4 pb-4 flex gap-2">
             <button

--- a/src/components/MediastackFeed.jsx
+++ b/src/components/MediastackFeed.jsx
@@ -59,6 +59,11 @@ export default function MediastackFeed({ count = 6 }) {
                 {truncate(sanitize(a.description), 120)}
               </p>
             )}
+            {a.published_at && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {new Date(a.published_at).toLocaleDateString()}
+              </p>
+            )}
           </div>
           <div className="px-4 pb-4 flex gap-2">
             <button

--- a/src/components/NewsFeed.jsx
+++ b/src/components/NewsFeed.jsx
@@ -53,6 +53,11 @@ export default function NewsFeed({ count = 10 }) {
             {item.summary && (
               <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{item.summary}</p>
             )}
+            {item.date && (
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                {new Date(item.date).toLocaleDateString()}
+              </p>
+            )}
             <div className="flex justify-end mt-2">
               <button
                 onClick={(e) => { e.stopPropagation(); shareText(item.title); }}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import MediastackFeed from '../components/MediastackFeed';
 import NewsFeed from '../components/NewsFeed';
 import GNewsFeed from '../components/GNewsFeed';
-import InfiniteNewsFeed from '../components/InfiniteNewsFeed';
+import AITechNewsFeed from '../components/AITechNewsFeed';
 import GoogleRssFeed from '../components/GoogleRssFeed';
 
 export default function Dashboard() {
@@ -43,9 +43,9 @@ export default function Dashboard() {
 </section>
       <div>
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-          Flux infini (GNews)
+          Actualités IA Technologie
         </h2>
-        <InfiniteNewsFeed batchSize={20} />
+        <AITechNewsFeed count={10} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace infinite GNews feed with new AI technology news section
- show publication dates in all news cards
- fetch AI-generated technology news via Groq

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876366d9b488331b78d2dbf5a3ce7fb