### PR TITLE
Add Pexels image search page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm run dev
 VITE_GROQ_KEY=sk-xxxxxxxxxxxxxxxxxxxx
 VITE_GNEWS_KEY=140c29519a8b267bda2474ccbd8b0f02
 VITE_MEDIASTACK_KEY=32f46c615a63368d99acc3b5b728fbfb
+VITE_PEXELS_KEY=your_pexels_api_key
 ```
 
 La clé `VITE_MEDIASTACK_KEY` permet d'afficher les actualités technologiques mondiales.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Dashboard from './pages/Dashboard';
 import StrategicView from './pages/StrategicView';
 import ContentGenerator from './pages/ContentGenerator';
 import TitleGenerator from './pages/TitleGenerator';
+import ImageSearch from './pages/ImageSearch';
 import Settings from './pages/Settings';
 import Notifications from './pages/Notifications';
 import Profile from './pages/Profile';
@@ -42,6 +43,7 @@ export default function App() {
                   <Route path="/strategic" element={<StrategicView />} />
                   <Route path="/content" element={<ContentGenerator />} />
                   <Route path="/titles" element={<TitleGenerator />} />
+                  <Route path="/images" element={<ImageSearch />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/notifications" element={<Notifications />} />
                   <Route path="/profile" element={<Profile />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,6 +5,7 @@ import {
   Layers,
   FileText,
   Sparkles,
+  Image as ImageIcon,
   Settings as SettingsIcon,
   Bell,
 } from 'lucide-react';
@@ -14,6 +15,7 @@ export const navItems = [
   { to: '/strategic', label: 'Vue stratégique', icon: Layers },
   { to: '/content', label: 'Générateur de contenu', icon: FileText },
   { to: '/titles', label: 'Générateur de titres', icon: Sparkles },
+  { to: '/images', label: 'Banque d\'images', icon: ImageIcon },
   { to: '/notifications', label: 'Notifications', icon: Bell },
   { to: '/settings', label: 'Paramètres', icon: SettingsIcon },
 ];

--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -11,7 +11,7 @@ import { useLanguage } from '../context/LanguageContext';
 import { Loader2, Twitter, Facebook, Linkedin, Download, Copy as CopyIcon } from 'lucide-react';
 import WordpressIcon from '../components/icons/WordpressIcon';
 import { shareTo } from '../utils/share';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useChatContext } from '../context/ChatContext';
 
 export default function ContentGenerator() {
@@ -28,6 +28,7 @@ export default function ContentGenerator() {
   const [toolResponse, setToolResponse] = useState('');
   const { lang } = useLanguage();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const handleGenerate = async (forcedTopic) => {
     const q = (forcedTopic ?? topic).trim();
@@ -273,6 +274,17 @@ export default function ContentGenerator() {
         <div className="mt-4">
           <h3 className="font-medium dark:text-gray-100">Mots-clés SEO</h3>
           <p className="text-sm dark:text-gray-300">{keywords.join(', ')}</p>
+        </div>
+      )}
+
+      {paragraphs.length > 0 && (
+        <div className="mt-6 flex justify-end">
+          <button
+            onClick={() => navigate('/images', { state: { keywords: keywords.join(' ') } })}
+            className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 text-sm"
+          >
+            Choisir une image
+          </button>
         </div>
       )}
     </div>

--- a/src/pages/ImageSearch.jsx
+++ b/src/pages/ImageSearch.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { Loader2 } from 'lucide-react';
+import { searchPexelsImages } from '../utils/pexelsApi';
+import { useLocation } from 'react-router-dom';
+
+export default function ImageSearch() {
+  const location = useLocation();
+  const [query, setQuery] = useState('');
+  const [images, setImages] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (location.state?.keywords) {
+      const k = location.state.keywords;
+      setQuery(k);
+      handleSearch(k);
+    }
+  }, [location.state]);
+
+  const handleSearch = async (forced) => {
+    const q = (forced ?? query).trim();
+    if (!q) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await searchPexelsImages(q, 16);
+      setImages(res);
+    } catch (e) {
+      console.error(e);
+      setError("Erreur lors de la recherche d'images");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-semibold dark:text-gray-100">Banque d'images Pexels</h1>
+      <div className="flex space-x-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Mots-clés..."
+          className="flex-1 px-3 py-2 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+        />
+        <button
+          disabled={loading}
+          onClick={() => handleSearch()}
+          className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 disabled:opacity-60 flex items-center justify-center"
+        >
+          {loading ? <Loader2 className="animate-spin" /> : 'Rechercher'}
+        </button>
+      </div>
+      {error && <p className="text-danger text-sm">{error}</p>}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+      >
+        {images.map((img) => (
+          <a key={img.id} href={img.url} target="_blank" rel="noopener noreferrer">
+            <img src={img.src} alt={img.alt} className="w-full h-40 object-cover rounded" />
+          </a>
+        ))}
+      </motion.div>
+    </div>
+  );
+}

--- a/src/utils/pexelsApi.js
+++ b/src/utils/pexelsApi.js
@@ -1,0 +1,10 @@
+export async function searchPexelsImages(query, perPage = 20) {
+  const apiKey = import.meta.env.VITE_PEXELS_KEY;
+  if (!apiKey) throw new Error('VITE_PEXELS_KEY not set');
+  const url = `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&per_page=${perPage}`;
+  const res = await fetch(url, { headers: { Authorization: apiKey } });
+  if (!res.ok) throw new Error(`Pexels error ${res.status}`);
+  const json = await res.json();
+  const photos = json.photos || [];
+  return photos.map(p => ({ id: p.id, src: p.src.medium, alt: p.alt || '', url: p.url }));
+}


### PR DESCRIPTION
## Summary
- integrate Pexels API helper
- add new ImageSearch page showing images from Pexels
- link image search from the sidebar and router
- allow navigation from content generator to image search
- document `VITE_PEXELS_KEY` env variable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68763bd19e588331afbd9c03fb79f64f