### PR TITLE
Support query params for title/content generators

### DIFF
--- a/src/components/GNewsFeed.jsx
+++ b/src/components/GNewsFeed.jsx
@@ -36,7 +36,7 @@ export default function GNewsFeed({ count = 6 }) {
       {articles.map((a, idx) => (
         <div
           key={idx}
-          onClick={() => navigate('/titles', { state: { topic: sanitize(a.title) } })}
+          onClick={() => navigate(`/titles?topic=${encodeURIComponent(sanitize(a.title))}`)}
           className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900 cursor-pointer"
         >
           <img

--- a/src/components/GoogleRssFeed.jsx
+++ b/src/components/GoogleRssFeed.jsx
@@ -59,7 +59,7 @@ export default function GoogleRssFeed({ count = 6 }) {
       {articles.map((a, idx) => (
         <div
           key={idx}
-          onClick={() => navigate('/titles', { state: { topic: sanitize(a.title) } })}
+          onClick={() => navigate(`/titles?topic=${encodeURIComponent(sanitize(a.title))}`)}
           className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900 cursor-pointer"
         >
           {a.image && (

--- a/src/components/InfiniteNewsFeed.jsx
+++ b/src/components/InfiniteNewsFeed.jsx
@@ -48,7 +48,7 @@ export default function InfiniteNewsFeed({ batchSize = 20 }) {
         {articles.map((a, idx) => (
           <div
             key={idx}
-            onClick={() => navigate('/titles', { state: { topic: sanitize(a.title) } })}
+            onClick={() => navigate(`/titles?topic=${encodeURIComponent(sanitize(a.title))}`)}
             className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900 cursor-pointer"
           >
             <img

--- a/src/components/MediastackFeed.jsx
+++ b/src/components/MediastackFeed.jsx
@@ -40,7 +40,7 @@ export default function MediastackFeed({ count = 6 }) {
       {articles.map((a, idx) => (
         <div
           key={idx}
-          onClick={() => navigate('/titles', { state: { topic: sanitize(a.title) } })}
+          onClick={() => navigate(`/titles?topic=${encodeURIComponent(sanitize(a.title))}`)}
           className="group rounded-2xl overflow-hidden shadow hover:shadow-lg transition bg-white dark:bg-gray-900 cursor-pointer"
         >
           {a.image && (

--- a/src/components/NewsFeed.jsx
+++ b/src/components/NewsFeed.jsx
@@ -46,7 +46,7 @@ export default function NewsFeed({ count = 10 }) {
         {news.map((item, idx) => (
           <li
             key={idx}
-            onClick={() => navigate('/content', { state: { topic: item.title } })}
+            onClick={() => navigate(`/content?topic=${encodeURIComponent(item.title)}`)}
             className="p-4 rounded-xl shadow bg-white dark:bg-gray-800 transition hover:shadow-lg cursor-pointer"
           >
             <h3 className="font-medium text-gray-900 dark:text-gray-100">{item.title}</h3>

--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -48,12 +48,15 @@ export default function ContentGenerator() {
   };
 
   useEffect(() => {
-    if (location.state?.topic) {
-      const t = location.state.topic;
+    const stateTopic = location.state?.topic;
+    const params = new URLSearchParams(location.search);
+    const queryTopic = params.get('topic');
+    const t = stateTopic || queryTopic;
+    if (t) {
       setTopic(t);
       handleGenerate(t);
     }
-  }, [location.state]);
+  }, [location.state, location.search]);
 
   useEffect(() => {
     setContext(paragraphs.join('\n'));

--- a/src/pages/TitleGenerator.jsx
+++ b/src/pages/TitleGenerator.jsx
@@ -25,12 +25,15 @@ export default function TitleGenerator() {
   const location = useLocation();
 
   useEffect(() => {
-    if (location.state?.topic) {
-      const t = location.state.topic;
+    const stateTopic = location.state?.topic;
+    const params = new URLSearchParams(location.search);
+    const queryTopic = params.get('topic');
+    const t = stateTopic || queryTopic;
+    if (t) {
       setTopic(t);
       handleGenerate(t);
     }
-  }, [location.state]);
+  }, [location.state, location.search]);
 
   useEffect(() => {
     setContext(titles.join('\n'));
@@ -142,7 +145,7 @@ export default function TitleGenerator() {
               Regénérer
             </button>
             <button
-              onClick={() => navigate('/content', { state: { topic: selected } })}
+              onClick={() => navigate(`/content?topic=${encodeURIComponent(selected)}`)}
               className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 text-sm"
             >
               Valider


### PR DESCRIPTION
## Summary
- support `topic` query param in TitleGenerator and ContentGenerator
- pass topic via query strings when navigating from article feeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68764070646c83319efb8d4e0c7ecb16