### PR TITLE
Fix generator buttons

### DIFF
--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -160,7 +160,7 @@ export default function ContentGenerator() {
         />
 
         <button
-          onClick={handleGenerate}
+          onClick={() => handleGenerate()}
           disabled={loading}
           className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 disabled:opacity-60 flex items-center justify-center"
         >

--- a/src/pages/TitleGenerator.jsx
+++ b/src/pages/TitleGenerator.jsx
@@ -109,10 +109,10 @@ export default function TitleGenerator() {
         />
         <button
           disabled={loading}
-          onClick={handleGenerate}
+          onClick={() => handleGenerate()}
           className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 disabled:opacity-60"
         >
-          {loading ? '...':'Générer'}
+          {loading ? '...' : 'Générer'}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- ensure the Générer buttons call generation functions without passing the click event

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68764319ff808331b278cefd38699d08