### PR TITLE
Add Deep Research feature using Serper

### DIFF
--- a/api/extract.js
+++ b/api/extract.js
@@ -1,0 +1,21 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+  const { url } = req.query;
+  if (!url) return res.status(400).json({ error: 'Missing url' });
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const cleaned = html
+      .replace(/<script[^>]*>.*?<\/script>/gis, '')
+      .replace(/<style[^>]*>.*?<\/style>/gis, '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    res.status(200).json({ text: cleaned.slice(0, 6000) });
+  } catch (err) {
+    console.error('Extract error:', err);
+    res.status(500).json({ error: 'Extraction failed', details: err.message });
+  }
+}

--- a/api/serper.js
+++ b/api/serper.js
@@ -1,0 +1,26 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+  const apiKey = process.env.SERPER_KEY || process.env.VITE_SERPER_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'SERPER_KEY env variable not set' });
+  }
+  const { q = '' } = req.query;
+  const body = JSON.stringify({ q: `${q} site:medium.com`, gl: 'fr', num: 5 });
+  try {
+    const response = await fetch('https://google.serper.dev/search', {
+      method: 'POST',
+      headers: {
+        'X-API-KEY': apiKey,
+        'Content-Type': 'application/json'
+      },
+      body
+    });
+    const text = await response.text();
+    res.status(response.status).send(text);
+  } catch (err) {
+    console.error('Serper proxy error:', err);
+    res.status(500).json({ error: 'Proxy error', details: err.message });
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import StrategicView from './pages/StrategicView';
 import ContentGenerator from './pages/ContentGenerator';
 import TitleGenerator from './pages/TitleGenerator';
 import ImageSearch from './pages/ImageSearch';
+import DeepResearch from './pages/DeepResearch';
 import Settings from './pages/Settings';
 import Notifications from './pages/Notifications';
 import Profile from './pages/Profile';
@@ -43,6 +44,7 @@ export default function App() {
                   <Route path="/strategic" element={<StrategicView />} />
                   <Route path="/content" element={<ContentGenerator />} />
                   <Route path="/titles" element={<TitleGenerator />} />
+                  <Route path="/research" element={<DeepResearch />} />
                   <Route path="/images" element={<ImageSearch />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/notifications" element={<Notifications />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,6 +6,7 @@ import {
   FileText,
   Sparkles,
   Image as ImageIcon,
+  Search,
   Settings as SettingsIcon,
   Bell,
 } from 'lucide-react';
@@ -15,6 +16,7 @@ export const navItems = [
   { to: '/strategic', label: 'Vue stratégique', icon: Layers },
   { to: '/content', label: 'Générateur de contenu', icon: FileText },
   { to: '/titles', label: 'Générateur de titres', icon: Sparkles },
+  { to: '/research', label: 'Deep Research', icon: Search },
   { to: '/images', label: 'Banque d\'images', icon: ImageIcon },
   { to: '/notifications', label: 'Notifications', icon: Bell },
   { to: '/settings', label: 'Paramètres', icon: SettingsIcon },

--- a/src/pages/DeepResearch.jsx
+++ b/src/pages/DeepResearch.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { Search } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+export default function DeepResearch() {
+  const [query, setQuery] = useState('');
+  const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSearch = async () => {
+    const q = query.trim();
+    if (!q) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/serper?q=${encodeURIComponent(q)}`);
+      if (!res.ok) throw new Error('Serper error');
+      const data = await res.json();
+      const item = (data.organic || []).find((r) => r.link && r.link.includes('medium.com'));
+      if (!item) throw new Error('Aucun article Medium trouvé');
+      const ext = await fetch(`/api/extract?url=${encodeURIComponent(item.link)}`);
+      if (!ext.ok) throw new Error('Erreur extraction');
+      const { text } = await ext.json();
+      const groqRes = await fetch('/api/groq', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'llama3-8b-8192',
+          messages: [
+            { role: 'system', content: 'Résume le texte suivant en français en trois points.' },
+            { role: 'user', content: text }
+          ]
+        })
+      });
+      const gjson = await groqRes.json();
+      const summary = gjson.choices?.[0]?.message?.content || '';
+      setResult({ title: item.title, link: item.link, summary });
+    } catch (e) {
+      console.error(e);
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-semibold dark:text-gray-100">Recherche approfondie</h1>
+      <div className="flex space-x-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Sujet de recherche..."
+          className="flex-1 px-3 py-2 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+        />
+        <button
+          onClick={handleSearch}
+          disabled={loading}
+          className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 disabled:opacity-60 flex items-center justify-center"
+        >
+          {loading ? (
+            <motion.span
+              animate={{ rotate: 360 }}
+              transition={{ repeat: Infinity, duration: 1, ease: 'linear' }}
+              className="block"
+            >
+              <Search size={18} />
+            </motion.span>
+          ) : (
+            'Chercher'
+          )}
+        </button>
+      </div>
+      {error && <p className="text-danger text-sm">{error}</p>}
+      {result && (
+        <div className="space-y-2">
+          <a href={result.link} target="_blank" rel="noopener noreferrer" className="text-brand-600 underline font-medium">
+            {result.title}
+          </a>
+          <p className="whitespace-pre-wrap text-gray-700 dark:text-gray-300">{result.summary}</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate Serper API via `/api/serper`
- fetch article content via `/api/extract`
- create **DeepResearch** page for searching and summarizing Medium articles
- add route and navigation entry

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765254d7c8833190f0c492b8069855