### PR TITLE
Add article editor with image integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import ContentGenerator from './pages/ContentGenerator';
 import TitleGenerator from './pages/TitleGenerator';
 import ImageSearch from './pages/ImageSearch';
 import DeepResearch from './pages/DeepResearch';
+import ArticleEditor from './pages/ArticleEditor';
 import Settings from './pages/Settings';
 import Notifications from './pages/Notifications';
 import Profile from './pages/Profile';
@@ -46,6 +47,7 @@ export default function App() {
                   <Route path="/titles" element={<TitleGenerator />} />
                   <Route path="/research" element={<DeepResearch />} />
                   <Route path="/images" element={<ImageSearch />} />
+                  <Route path="/editor" element={<ArticleEditor />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/notifications" element={<Notifications />} />
                   <Route path="/profile" element={<Profile />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,6 +9,7 @@ import {
   Search,
   Settings as SettingsIcon,
   Bell,
+  Pencil,
 } from 'lucide-react';
 
 export const navItems = [
@@ -18,6 +19,7 @@ export const navItems = [
   { to: '/titles', label: 'Générateur de titres', icon: Sparkles },
   { to: '/research', label: 'Deep Research', icon: Search },
   { to: '/images', label: 'Banque d\'images', icon: ImageIcon },
+  { to: '/editor', label: 'Éditeur', icon: Pencil },
   { to: '/notifications', label: 'Notifications', icon: Bell },
   { to: '/settings', label: 'Paramètres', icon: SettingsIcon },
 ];

--- a/src/pages/ArticleEditor.jsx
+++ b/src/pages/ArticleEditor.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ArticleEditor() {
+  const location = useLocation();
+  const { title = '', paragraphs = [], image } = location.state || {};
+  const editorRef = useRef(null);
+  const [html, setHtml] = useState('');
+
+  useEffect(() => {
+    if (editorRef.current) {
+      const initial = `${title ? `<h1>${title}</h1>` : ''}` +
+        `${image ? `<img src="${image}" alt="" style="max-width:100%;"/>` : ''}` +
+        paragraphs.map(p => `<p>${p}</p>`).join('');
+      editorRef.current.innerHTML = initial;
+      setHtml(initial);
+    }
+  }, [title, paragraphs, image]);
+
+  const exec = (cmd) => {
+    document.execCommand(cmd, false, null);
+    setHtml(editorRef.current.innerHTML);
+  };
+
+  const updateHtml = () => {
+    setHtml(editorRef.current.innerHTML);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold dark:text-gray-100">Éditeur d'article</h1>
+      <div className="flex flex-col lg:flex-row gap-4">
+        <div className="flex-1 space-y-2">
+          <div className="flex flex-wrap gap-2 bg-gray-100 dark:bg-gray-800 p-2 rounded">
+            <button onClick={() => exec('bold')} className="px-2 py-1 border rounded text-sm">B</button>
+            <button onClick={() => exec('italic')} className="px-2 py-1 border rounded text-sm">I</button>
+            <button onClick={() => exec('underline')} className="px-2 py-1 border rounded text-sm">U</button>
+            <button onClick={() => exec('insertUnorderedList')} className="px-2 py-1 border rounded text-sm">• List</button>
+            <button onClick={() => exec('insertOrderedList')} className="px-2 py-1 border rounded text-sm">1. List</button>
+          </div>
+          <div
+            ref={editorRef}
+            onInput={updateHtml}
+            className="min-h-[300px] p-3 border rounded bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100"
+            contentEditable
+            suppressContentEditableWarning
+          />
+        </div>
+        <div className="lg:w-1/2 bg-gray-50 dark:bg-gray-800 p-3 rounded overflow-auto">
+          <h2 className="font-medium mb-2 text-gray-800 dark:text-gray-100">HTML</h2>
+          <pre className="text-sm whitespace-pre-wrap break-all">{html}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -283,7 +283,15 @@ export default function ContentGenerator() {
       {paragraphs.length > 0 && (
         <div className="mt-6 flex justify-end">
           <button
-            onClick={() => navigate('/images', { state: { keywords: keywords.join(' ') } })}
+            onClick={() =>
+              navigate('/images', {
+                state: {
+                  keywords: keywords.join(' '),
+                  title: topic,
+                  paragraphs,
+                },
+              })
+            }
             className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 text-sm"
           >
             Choisir une image

--- a/src/pages/ImageSearch.jsx
+++ b/src/pages/ImageSearch.jsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Loader2 } from 'lucide-react';
 import { searchPexelsImages } from '../utils/pexelsApi';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function ImageSearch() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [query, setQuery] = useState('');
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -60,9 +61,21 @@ export default function ImageSearch() {
         className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
       >
         {images.map((img) => (
-          <a key={img.id} href={img.url} target="_blank" rel="noopener noreferrer">
+          <button
+            key={img.id}
+            onClick={() =>
+              navigate('/editor', {
+                state: {
+                  image: img.src,
+                  title: location.state?.title,
+                  paragraphs: location.state?.paragraphs,
+                },
+              })
+            }
+            className="focus:outline-none"
+          >
             <img src={img.src} alt={img.alt} className="w-full h-40 object-cover rounded" />
-          </a>
+          </button>
         ))}
       </motion.div>
     </div>


### PR DESCRIPTION
## Summary
- add new `ArticleEditor` page with simple rich text editor and HTML preview
- update sidebar navigation with link to the editor
- allow generated content to forward title & paragraphs when picking images
- after selecting an image, open editor with image, title, and paragraphs prefilled
- register `/editor` route in the app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765c38dbe083319c385ee69b98eb84