### PR TITLE
Add install overlays and article enhancer

### DIFF
--- a/src/pages/DeepResearch.jsx
+++ b/src/pages/DeepResearch.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Search } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { summarizeArticle } from '../utils/groqNews';
@@ -47,6 +47,12 @@ export default function DeepResearch() {
   const [error, setError] = useState(null);
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState('');
+  const [installing, setInstalling] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setInstalling(false), 2000);
+    return () => clearTimeout(t);
+  }, []);
 
   const handleSearch = async () => {
     const q = query.trim();
@@ -92,7 +98,22 @@ export default function DeepResearch() {
   };
 
   return (
-    <div className="p-6 space-y-6 max-w-3xl mx-auto">
+    <div className="p-6 space-y-6 max-w-3xl mx-auto relative">
+      <AnimatePresence>
+        {installing && (
+          <motion.div
+            key="install"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <div className="bg-white dark:bg-gray-900 p-4 rounded shadow text-sm text-gray-800 dark:text-gray-100">
+              Installation des dépendances...
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
       <h1 className="text-2xl font-semibold dark:text-gray-100">Recherche approfondie</h1>
       <div className="flex space-x-2">
         <input

--- a/src/utils/groqNews.js
+++ b/src/utils/groqNews.js
@@ -459,3 +459,24 @@ export async function summarizeArticle(text, lang = 'fr') {
     return { summary: jsonText.trim(), points: [] };
   }
 }
+
+/**
+ * Enhance an article using AI to produce a polished result.
+ * @param {string} html Article HTML content
+ * @returns {Promise<string>} Improved HTML
+ */
+export async function enhanceArticle(html, lang = 'fr') {
+  if (!html) return '';
+  const text = await chatCompletion(
+    [
+      {
+        role: 'system',
+        content: `You are the world's best ${name(lang)} editor. Improve the article below while preserving its meaning. Return polished HTML in ${name(lang)}.`
+      },
+      { role: 'user', content: html.slice(0, 6000) }
+    ],
+    { max_tokens: 2000, temperature: 0.7 }
+  );
+  return text.trim();
+}
+


### PR DESCRIPTION
## Summary
- show a fake install overlay when opening Deep Research
- show a fake install overlay when opening Article Editor
- add an AI-powered `enhanceArticle` helper
- allow improving articles in the editor with a new button

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68765e8cdd0c83319402766187f67ee4