### PR TITLE
Ensure editor is focused on load

### DIFF
--- a/src/pages/ArticleEditor.jsx
+++ b/src/pages/ArticleEditor.jsx
@@ -13,6 +13,7 @@ export default function ArticleEditor() {
   const [enhancing, setEnhancing] = useState(false);
 
   useEffect(() => {
+    if (editorRef.current) editorRef.current.focus();
     let p = 0;
     const interval = setInterval(() => {
       p += 1;


### PR DESCRIPTION
## Summary
- focus the editor immediately on mount so early keystrokes are kept

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68766869918883319fa5222df299ceb6