### PR TITLE
Enable title generator navigation and fix Google RSS feed

### DIFF
--- a/api/googleNewsRss.js
+++ b/api/googleNewsRss.js
@@ -6,7 +6,9 @@ export default async function handler(req, res) {
   const { q = '' } = req.query;
   const url = `https://news.google.com/rss/search?q=${encodeURIComponent(q)}&hl=fr&gl=FR&ceid=FR:fr`;
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0' }
+    });
     const text = await response.text();
     res.status(response.status).send(text);
   } catch (err) {

--- a/src/components/AITechNewsFeed.jsx
+++ b/src/components/AITechNewsFeed.jsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 import { fetchAITechNews } from '../utils/groqNews';
 import Skeleton from './ui/Skeleton';
 import { useLanguage } from '../context/LanguageContext';
+import { useNavigate } from 'react-router-dom';
 
 export default function AITechNewsFeed({ count = 10 }) {
   const [news, setNews] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const { lang } = useLanguage();
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchAITechNews(count, lang)
@@ -33,7 +35,13 @@ export default function AITechNewsFeed({ count = 10 }) {
   return (
     <ul className="space-y-4">
       {news.map((item, idx) => (
-        <li key={idx} className="p-4 rounded-xl shadow bg-white dark:bg-gray-800">
+        <li
+          key={idx}
+          onClick={() =>
+            navigate(`/titles?topic=${encodeURIComponent(item.title)}`)
+          }
+          className="p-4 rounded-xl shadow bg-white dark:bg-gray-800 cursor-pointer"
+        >
           <h3 className="font-medium text-gray-900 dark:text-gray-100">{item.title}</h3>
           {item.summary && (
             <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{item.summary}</p>

--- a/src/components/GoogleRssFeed.jsx
+++ b/src/components/GoogleRssFeed.jsx
@@ -53,6 +53,7 @@ export default function GoogleRssFeed({ count = 6 }) {
     );
 
   if (error) return <p className="text-danger text-sm">Impossible de charger les nouvelles.</p>;
+  if (articles.length === 0) return <p className="text-sm">Aucun article disponible.</p>;
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -296,6 +296,14 @@ export default function ContentGenerator() {
           >
             Choisir une image
           </button>
+          <button
+            onClick={() =>
+              navigate(`/titles?topic=${encodeURIComponent(topic)}`)
+            }
+            className="ml-2 px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 text-sm"
+          >
+            Générer des titres
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- link AI technology news items to the title generator
- add a button in the content generator to access the title generator
- show a message when Google RSS has no articles and send a user‑agent header

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68775ab39268833190797503403ffa5e