### PR TITLE
Add content planning page with sidebar link

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import TitleGenerator from './pages/TitleGenerator';
 import ImageSearch from './pages/ImageSearch';
 import DeepResearch from './pages/DeepResearch';
 import ArticleEditor from './pages/ArticleEditor';
+import ContentPlanning from './pages/ContentPlanning';
 import Settings from './pages/Settings';
 import Notifications from './pages/Notifications';
 import Profile from './pages/Profile';
@@ -48,6 +49,7 @@ export default function App() {
                   <Route path="/research" element={<DeepResearch />} />
                   <Route path="/images" element={<ImageSearch />} />
                   <Route path="/editor" element={<ArticleEditor />} />
+                  <Route path="/planning" element={<ContentPlanning />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/notifications" element={<Notifications />} />
                   <Route path="/profile" element={<Profile />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -7,6 +7,7 @@ import {
   Sparkles,
   Image as ImageIcon,
   Search,
+  Calendar,
   Settings as SettingsIcon,
   Bell,
   Pencil,
@@ -20,6 +21,7 @@ export const navItems = [
   { to: '/research', label: 'Deep Research', icon: Search },
   { to: '/images', label: 'Banque d\'images', icon: ImageIcon },
   { to: '/editor', label: 'Éditeur', icon: Pencil },
+  { to: '/planning', label: 'Planification de contenu', icon: Calendar },
   { to: '/notifications', label: 'Notifications', icon: Bell },
   { to: '/settings', label: 'Paramètres', icon: SettingsIcon },
 ];

--- a/src/pages/ContentPlanning.jsx
+++ b/src/pages/ContentPlanning.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+export default function ContentPlanning() {
+  const [events, setEvents] = useState([
+    { id: 1, title: 'Article sur l\'IA', date: '2024-06-01' },
+    { id: 2, title: 'Post réseaux sociaux', date: '2024-06-05' }
+  ]);
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+
+  const addEvent = () => {
+    if (title && date) {
+      setEvents([...events, { id: Date.now(), title, date }]);
+      setTitle('');
+      setDate('');
+    }
+  };
+
+  const deleteEvent = (id) => {
+    setEvents(events.filter(e => e.id !== id));
+  };
+
+  return (
+    <div className="space-y-6 max-w-xl">
+      <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Planification de contenu</h1>
+      <div className="bg-white dark:bg-gray-900 rounded shadow p-4 space-y-4">
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            placeholder="Titre"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            className="flex-1 border rounded px-2 py-1 dark:bg-gray-800 dark:border-gray-700"
+          />
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+            className="border rounded px-2 py-1 dark:bg-gray-800 dark:border-gray-700"
+          />
+          <button
+            onClick={addEvent}
+            className="bg-brand text-white px-3 py-1 rounded"
+          >
+            Ajouter
+          </button>
+        </div>
+        <ul className="divide-y dark:divide-gray-700">
+          {events.map(e => (
+            <li key={e.id} className="flex justify-between py-2">
+              <span className="text-gray-700 dark:text-gray-300">{e.title} - {e.date}</span>
+              <button
+                onClick={() => deleteEvent(e.id)}
+                className="text-red-500 hover:underline"
+              >
+                Supprimer
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ContentPlanning page to manage scheduled posts
- link to the new page from the sidebar and mobile sidebar
- register the new route in the app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877697b8d80833180b6e12ba9374f95