### PR TITLE
Implement scheduling via ChatBot

### DIFF
--- a/src/pages/ContentPlanning.jsx
+++ b/src/pages/ContentPlanning.jsx
@@ -1,24 +1,85 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useChatContext } from '../context/ChatContext';
 
 export default function ContentPlanning() {
-  const [events, setEvents] = useState([
-    { id: 1, title: 'Article sur l\'IA', date: '2024-06-01' },
-    { id: 2, title: 'Post réseaux sociaux', date: '2024-06-05' }
-  ]);
+  const { setOnAction } = useChatContext();
+  const [events, setEvents] = useState(() => {
+    const stored = localStorage.getItem('planningEvents');
+    return stored ? JSON.parse(stored) : [
+      { id: 1, title: "Article sur l'IA", date: '2024-06-01' },
+      { id: 2, title: 'Post réseaux sociaux', date: '2024-06-05' }
+    ];
+  });
   const [title, setTitle] = useState('');
   const [date, setDate] = useState('');
 
-  const addEvent = () => {
-    if (title && date) {
-      setEvents([...events, { id: Date.now(), title, date }]);
-      setTitle('');
-      setDate('');
+  const addEvent = (t = title, d = date) => {
+    if (t && d) {
+      setEvents(prev => [...prev, { id: Date.now(), title: t, date: d }]);
+      if (t === title) setTitle('');
+      if (d === date) setDate('');
     }
   };
 
   const deleteEvent = (id) => {
     setEvents(events.filter(e => e.id !== id));
   };
+
+  const parseDateTime = (text) => {
+    const t = text.toLowerCase();
+    const now = new Date();
+    let d = null;
+    if (/(today|aujourd'hui)/.test(t)) {
+      d = new Date(now);
+    } else if (/(tomorrow|demain)/.test(t)) {
+      d = new Date(now);
+      d.setDate(now.getDate() + 1);
+    } else {
+      const m = t.match(/(\d{4}-\d{2}-\d{2})/);
+      if (m) d = new Date(m[1]);
+    }
+    const time = t.match(/(\d{1,2})(?:[:h](\d{2}))?\s*(am|pm)?/);
+    if (d && time) {
+      let h = parseInt(time[1], 10);
+      const min = parseInt(time[2] || '0', 10);
+      const ap = time[3];
+      if (ap === 'pm' && h < 12) h += 12;
+      if (ap === 'am' && h === 12) h = 0;
+      d.setHours(h, min, 0, 0);
+    }
+    return d;
+  };
+
+  const handleAction = (cmd) => {
+    const low = cmd.toLowerCase();
+    if (/add|ajouter|schedul|planifier/.test(low)) {
+      const dt = parseDateTime(low);
+      if (!dt) return "Je n'ai pas compris la date";
+      const dStr = dt.toISOString().slice(0, 10);
+      const cleaned = cmd
+        .replace(/\/action/i, '')
+        .replace(/add|ajouter|schedule|schedul|planifier/gi, '')
+        .replace(/today|tomorrow|aujourd'hui|demain/gi, '')
+        .replace(/\d{4}-\d{2}-\d{2}/, '')
+        .replace(/\d{1,2}(?::\d{2})?\s*(?:am|pm)?/, '')
+        .replace(/\bat\b|\bà\b/, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      const t = cleaned || 'Évènement';
+      addEvent(t, dStr);
+      return `Évènement "${t}" ajouté pour le ${dStr}.`;
+    }
+    return 'Commande inconnue.';
+  };
+
+  useEffect(() => {
+    setOnAction(() => handleAction);
+    return () => setOnAction(null);
+  }, [events]);
+
+  useEffect(() => {
+    localStorage.setItem('planningEvents', JSON.stringify(events));
+  }, [events]);
 
   return (
     <div className="space-y-6 max-w-xl">


### PR DESCRIPTION
## Summary
- improve content planning page with persistent events
- add ChatBot `/action` handler so users can schedule items in natural language

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68776db78d30833180c17170bad0588b