### PR TITLE
Add static technology news

### DIFF
--- a/src/components/TechnologyNews.jsx
+++ b/src/components/TechnologyNews.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { technologyNews } from '../data/technologyNews';
+
+export default function TechnologyNews() {
+  return (
+    <div className="space-y-6">
+      {technologyNews.map((section) => (
+        <div key={section.category} className="space-y-3">
+          <h3 className="text-md font-semibold text-gray-800 dark:text-gray-100">
+            {section.category}
+          </h3>
+          <ul className="space-y-4">
+            {section.items.map((item, idx) => (
+              <li
+                key={idx}
+                className="p-4 rounded-xl shadow bg-white dark:bg-gray-800"
+              >
+                <h4 className="font-medium text-gray-900 dark:text-gray-100">
+                  {item.title}
+                </h4>
+                {item.summary && (
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+                    {item.summary}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/data/technologyNews.js
+++ b/src/data/technologyNews.js
@@ -1,0 +1,126 @@
+export const technologyNews = [
+  {
+    category: 'Consumer Devices & AI',
+    items: [
+      {
+        title: 'Samsung Galaxy Unpacked – Z Fold\u202f7, Z Flip\u202f7 & Watch\u202f8',
+        summary:
+          'Revealed in New York: ultra-thin foldables with 200\u202fMP cameras, Gemini AI features, and smartwatches tracking vascular load & antioxidants',
+      },
+      {
+        title: 'Google Gemini AI appears across Wear OS & Android',
+        summary:
+          'Gemini-powered chatbots land in Android side panels and start enhancing foldable experiences',
+      },
+      {
+        title: 'Pixel\u202f10 prototype leaks',
+        summary: 'Early models hint at a Tensor G5 chip and triple-camera setup',
+      },
+      {
+        title: 'Ray\u2011Ban Meta smart glasses leaked',
+        summary: 'Next-gen hardware may introduce AI-driven UI and longer battery life',
+      },
+    ],
+  },
+  {
+    category: 'AI & Semiconductors',
+    items: [
+      {
+        title: 'Nvidia to resume H20 AI chip exports to China',
+        summary:
+          'US export control reversal follows high\u2011level talks, boosting Nvidia\u2019s Chinese market access',
+      },
+      {
+        title: 'Nvidia becomes first $4\u202ftrillion company',
+        summary:
+          'Surpasses UK stock market in value, driven by booming AI demand',
+      },
+      {
+        title: 'Microsoft partners with national labs on nuclear plant permitting',
+        summary:
+          'AI to accelerate paperwork for new nuclear reactors',
+      },
+      {
+        title: 'NVIDIA launches AI tool for editing 3D scenes',
+        summary: 'Enables photorealistic, scene-aware 3D generation',
+      },
+    ],
+  },
+  {
+    category: 'Tech Industry & Infrastructure',
+    items: [
+      {
+        title: 'TSMC delays Japan plant, shifts focus to US',
+        summary:
+          'Construction of second Japan wafer facility postponed amid US expansion',
+      },
+      {
+        title: 'Meta invests billions in AI data centers',
+        summary:
+          'Meta rolls out large-scale campuses Prometheus & Hyperion',
+      },
+      {
+        title: 'AI-augmented lab automation accelerates discoveries',
+        summary: 'New system boosts experimental throughput 10\u00d7',
+      },
+    ],
+  },
+  {
+    category: 'Energy, Policy & Economy',
+    items: [
+      {
+        title: 'Trump announces $70\u202fb AI & energy plan at summit',
+        summary:
+          'At Carnegie Mellon: trilateral effort blending tech and fossil fuel initiatives',
+      },
+      {
+        title: 'U.S.\u2013China thaw on AI chips',
+        summary:
+          'Resumed Nvidia H20 chip sales signal a shift in trade relations',
+      },
+      {
+        title: 'AI puts pressure on energy grids',
+        summary:
+          'Data center demand rising—nuclear, renewables, policy permit fast\u2011tracking included',
+      },
+    ],
+  },
+  {
+    category: 'Science & Emerging Tech',
+    items: [
+      {
+        title: 'Singapore uses AI to accelerate materials science',
+        summary:
+          'Simulation-backed discovery aiming for sustainable compounds',
+      },
+      {
+        title: 'Quantum breakthroughs',
+        summary:
+          "Microsoft's Majorana\u202f1 chip edges quantum computing closer to reality",
+      },
+      {
+        title: 'Waning methane sat and new interstellar visitor',
+        summary: 'MethaneSAT loses contact; 3I/ATLAS enters our solar system',
+      },
+      {
+        title: 'Black hole merger record smashed',
+        summary:
+          'LIGO\u2011Virgo-KAGRA detect most massive ever at ~225\u202fM\u2609',
+      },
+    ],
+  },
+  {
+    category: 'Hardware & Gadgets',
+    items: [
+      {
+        title:
+          'Top gadgets of July: From tactile phone cases to modular MicroPCs & wireless charging trees',
+      },
+      {
+        title: 'Lab-built 20\u2011electron ferrocene breakthrough',
+        summary:
+          'Chemistry researchers shatter the 18\u2011electron rule, opening new materials',
+      },
+    ],
+  },
+];

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,46 +1,37 @@
 
-import React, { useMemo } from 'react';
-import MediastackFeed from '../components/MediastackFeed';
+import React from 'react';
 import NewsFeed from '../components/NewsFeed';
 import GNewsFeed from '../components/GNewsFeed';
 import AITechNewsFeed from '../components/AITechNewsFeed';
-import GoogleRssFeed from '../components/GoogleRssFeed';
+import TechnologyNews from '../components/TechnologyNews';
 
 export default function Dashboard() {
-  const googleCount = useMemo(() => Math.floor(Math.random() * 5) + 6, []);
   return (
     <div className="space-y-6">
-
       <section className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-  <div className="space-y-6">
-    <div>
-      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-        Actualités technologie (Monde)
-      </h2>
-      <MediastackFeed count={10} />
-    </div>
-    <div>
-      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-        Google News (RSS)
-      </h2>
-      <GoogleRssFeed count={googleCount} />
-    </div>
-  </div>
-  <div className="space-y-6">
-    <div>
-      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-        Dernières nouvelles (GNews)
-      </h2>
-      <GNewsFeed count={6} />
-    </div>
-    <div>
-      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
-        Actualités Maroc
-      </h2>
-      <NewsFeed count={10} />
-    </div>
-  </div>
-</section>
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+              Dernières nouvelles (GNews)
+            </h2>
+            <GNewsFeed count={6} />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+              Actualités Maroc
+            </h2>
+            <NewsFeed count={10} />
+          </div>
+        </div>
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
+              Technologie News
+            </h2>
+            <TechnologyNews />
+          </div>
+        </div>
+      </section>
       <div>
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">
           Actualités IA Technologie


### PR DESCRIPTION
## Summary
- replace Google RSS and Mediastack sections with new Technology News section
- create `technologyNews` dataset
- show those items in new `TechnologyNews` component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877a736b5c483318dc413555f4ee151