### PR TITLE
Add global chatbot actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ Le projet a été réalisé dans le cadre d’un **stage d’initiation de 3ᵉ 
 - 📲 **Suggestion d'horaire optimal** : recommande le meilleur moment de publication selon l'engagement de l'audience
 - 🤖 **Commandes chatbot** : `/action add`, `list`, `delete <n>` ou `clear`
 
+### Commandes par page
+
+| Page | Commandes |
+|------|-----------|
+| Tableau de bord | `help` |
+| Vue stratégique | `help` |
+| Générateur de contenu | `regenerate`, `help` |
+| Générateur de titres | `regenerate`, `help` |
+| Recherche d'images | `search <mots>`, `help` |
+| Recherche approfondie | `help` |
+| Éditeur d'article | `help` |
+| Planning de contenu | `add`, `list`, `delete <n>`, `clear`, `help` |
+| Notifications | `clear`, `help` |
+| Paramètres | `dark on`, `light`, `help` |
+| Profil | `help` |
+| Archives | `help` |
+| Connexion | `help` |
+
 Exemple :
 
 ```bash

--- a/src/pages/Archives.jsx
+++ b/src/pages/Archives.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { useChatContext } from '../context/ChatContext';
 
 const articles = Array.from({ length: 20 }, (_, i) => ({
   id: i + 1,
@@ -9,6 +10,16 @@ const articles = Array.from({ length: 20 }, (_, i) => ({
 }));
 
 export default function Archives() {
+  const { setOnAction } = useChatContext();
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) return 'Commandes: /action help';
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Archives</h1>

--- a/src/pages/ArticleEditor.jsx
+++ b/src/pages/ArticleEditor.jsx
@@ -22,6 +22,16 @@ export default function ArticleEditor() {
   const { setContext, setOnAction } = useChatContext();
 
   useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) {
+        return 'Éditez votre article puis sauvegardez automatiquement.';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
+  useEffect(() => {
     if (editorRef.current) editorRef.current.focus();
     let p = 0;
     const interval = setInterval(() => {

--- a/src/pages/Connexion.jsx
+++ b/src/pages/Connexion.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Mail, Lock } from 'lucide-react';
 import { useTheme } from '../context/ThemeContext';
 import { useAuth } from '../context/AuthContext';
+import { useChatContext } from '../context/ChatContext';
 
 export default function Connexion() {
   const [email, setCourriel] = useState('');
@@ -12,6 +13,17 @@ export default function Connexion() {
   const navigate = useNavigate();
   const { dark } = useTheme();
   const { login, user } = useAuth();
+  const { setOnAction } = useChatContext();
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) {
+        return 'Utilisez le formulaire pour vous connecter.';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
 
   useEffect(() => {
     if (user) {

--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -61,7 +61,14 @@ export default function ContentGenerator() {
   useEffect(() => {
     setContext(paragraphs.join('\n'));
     setOnAction(() => (cmd) => {
-      if (cmd.startsWith('regenerate')) handleGenerate(topic);
+      if (cmd.startsWith('regenerate')) {
+        handleGenerate(topic);
+        return 'Contenu régénéré.';
+      }
+      if (/help/i.test(cmd)) {
+        return 'Commandes: /action regenerate';
+      }
+      return 'Commande inconnue.';
     });
     return () => {
       setOnAction(null);

--- a/src/pages/ContentPlanning.jsx
+++ b/src/pages/ContentPlanning.jsx
@@ -104,6 +104,10 @@ export default function ContentPlanning() {
       return `Évènement "${t}" ajouté pour le ${dStr}.`;
     }
 
+    if (/help/i.test(low)) {
+      return 'Commandes: add, list, delete <n>, clear';
+    }
+
     return 'Commande inconnue.';
   };
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,24 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import NewsFeed from '../components/NewsFeed';
 import GNewsFeed from '../components/GNewsFeed';
 import AITechNewsFeed from '../components/AITechNewsFeed';
 import TechnologyNews from '../components/TechnologyNews';
+import { useChatContext } from '../context/ChatContext';
 
 export default function Dashboard() {
+  const { setOnAction } = useChatContext();
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) {
+        return 'Commandes disponibles: /action help (affiche cette aide)';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
   return (
     <div className="space-y-6">
       <section className="grid grid-cols-1 xl:grid-cols-2 gap-6">

--- a/src/pages/DeepResearch.jsx
+++ b/src/pages/DeepResearch.jsx
@@ -53,6 +53,14 @@ export default function DeepResearch() {
   const { setContext, setOnAction } = useChatContext();
 
   useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) return 'Commande: /action help';
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
+  useEffect(() => {
     if (results.length > 0) {
       const text = results
         .map(r => `${r.title}${r.summary ? `: ${r.summary}` : ''}`)

--- a/src/pages/ImageSearch.jsx
+++ b/src/pages/ImageSearch.jsx
@@ -3,14 +3,33 @@ import { motion } from 'framer-motion';
 import { Loader2 } from 'lucide-react';
 import { searchPexelsImages } from '../utils/pexelsApi';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useChatContext } from '../context/ChatContext';
 
 export default function ImageSearch() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { setOnAction } = useChatContext();
   const [query, setQuery] = useState('');
   const [images, setImages] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      const m = cmd.match(/search\s+(.+)/i);
+      if (m) {
+        const q = m[1].trim();
+        setQuery(q);
+        handleSearch(q);
+        return `Recherche d'images pour "${q}"...`;
+      }
+      if (/help/i.test(cmd)) {
+        return 'Commandes: /action search <mots-clés>'; 
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
 
   useEffect(() => {
     if (location.state?.keywords) {

--- a/src/pages/Notifications.jsx
+++ b/src/pages/Notifications.jsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useChatContext } from '../context/ChatContext';
 
 const randomUsers = ['Alice', 'Bob', 'Charlie', 'Diana', 'Ethan', 'Fatima'];
 const randomMsgs = [
@@ -16,9 +17,26 @@ function randomNotif(i) {
   return { id: i, text: `${user} ${msg}`, time: `il y a ${Math.floor(Math.random()*59)+1} min` };
 }
 
-const notifications = Array.from({length:15}, (_,i)=> randomNotif(i));
-
 export default function Notifications() {
+  const { setOnAction } = useChatContext();
+  const [notifications, setNotifications] = useState(() =>
+    Array.from({ length: 15 }, (_, i) => randomNotif(i))
+  );
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/clear/i.test(cmd)) {
+        setNotifications([]);
+        return 'Notifications effacées.';
+      }
+      if (/help/i.test(cmd)) {
+        return 'Commandes: /action clear';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4 text-gray-800 dark:text-gray-100">Notifications</h1>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,6 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useChatContext } from '../context/ChatContext';
 
 export default function Profile() {
+  const { setOnAction } = useChatContext();
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) {
+        return 'Commandes disponibles: /action help';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
   return (
     <div className="max-w-lg space-y-6">
       <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Profil</h1>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,13 +1,33 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTheme } from '../context/ThemeContext';
 import { usePreferences } from '../context/PreferenceContext';
 import { useLanguage } from '../context/LanguageContext';
+import { useChatContext } from '../context/ChatContext';
 
 export default function Settings() {
   const { dark, toggle: toggleDark } = useTheme();
   const [emailNotif, setCourrielNotif] = useState(true);
   const { categories, toggleCategory } = usePreferences();
   const { lang, setLang } = useLanguage();
+  const { setOnAction } = useChatContext();
+
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/dark\s*(on)?/i.test(cmd)) {
+        if (!dark) toggleDark();
+        return 'Mode sombre activé';
+      }
+      if (/light|clair/i.test(cmd)) {
+        if (dark) toggleDark();
+        return 'Mode clair activé';
+      }
+      if (/help/i.test(cmd)) {
+        return 'Commandes: /action dark on | light';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, [dark]);
 
   return (
     <div className="flex justify-center pt-10 px-4">

--- a/src/pages/StrategicView.jsx
+++ b/src/pages/StrategicView.jsx
@@ -2,7 +2,7 @@
 // src/pages/StrategicView.jsx
 // Dark-mode polished Vue stratégique
 // ────────────────────────────────────────────────────────────────────────────────
-import React from "react";
+import React, { useEffect } from "react";
 import {
   Card,
   CardContent,
@@ -21,6 +21,7 @@ import {
   Bar,
 } from "recharts";
 import { motion } from "framer-motion";
+import { useChatContext } from '../context/ChatContext';
 
 /* THEME COLORS */
 const PRIMARY = "#1e90ff";            // main accent
@@ -220,7 +221,19 @@ const KeywordsListCard = () => {
 /* ────────────────────────────────────────────────────────────────────────── */
 /* Main Vue stratégique                                                     */
 /* ────────────────────────────────────────────────────────────────────────── */
-const StrategicView = () => (
+const StrategicView = () => {
+  const { setOnAction } = useChatContext();
+  useEffect(() => {
+    setOnAction(() => (cmd) => {
+      if (/help/i.test(cmd)) {
+        return 'Commandes disponibles: /action help (affiche cette aide)';
+      }
+      return 'Commande inconnue.';
+    });
+    return () => setOnAction(null);
+  }, []);
+
+  return (
   <div className="grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
     {/* Row 1 */}
     <div className="flex flex-col gap-6 xl:flex-row xl:col-span-2">
@@ -235,6 +248,7 @@ const StrategicView = () => (
     <CountriesListCard />
     <KeywordsListCard />
   </div>
-);
+  );
+};
 
 export default StrategicView;

--- a/src/pages/TitleGenerator.jsx
+++ b/src/pages/TitleGenerator.jsx
@@ -38,7 +38,14 @@ export default function TitleGenerator() {
   useEffect(() => {
     setContext(titles.join('\n'));
     setOnAction(() => (cmd) => {
-      if (cmd.startsWith('regenerate')) handleGenerate(topic);
+      if (cmd.startsWith('regenerate')) {
+        handleGenerate(topic);
+        return 'Titres régénérés.';
+      }
+      if (/help/i.test(cmd)) {
+        return 'Commandes: /action regenerate';
+      }
+      return 'Commande inconnue.';
     });
     return () => {
       setOnAction(null);


### PR DESCRIPTION
## Summary
- handle `/action` chatbot commands on every page
- document available commands in README
- show example action-based search on image page
- allow clearing notifications through chat
- support dark-mode toggling via chat

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877ad9c42f88331af524a88a2e07987