### PR TITLE
Fix image search keywords

### DIFF
--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -103,11 +103,11 @@ export default function ContentGenerator() {
   };
 
   const handleChooseImage = async () => {
-    let q = keywords.join(' ');
+    let q = keywords[0] ?? '';
     try {
       const aiKw = await generateImageKeywords(topic, 3);
       if (aiKw && aiKw.length > 0) {
-        q = aiKw.join(' ');
+        q = aiKw[0];
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- only pass the first generated keyword when opening the image search page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878ed58bf888331bdb480bf6a8dcb44