### PR TITLE
Improve humanizer and image query

### DIFF
--- a/src/pages/ContentGenerator.jsx
+++ b/src/pages/ContentGenerator.jsx
@@ -8,6 +8,7 @@ import {
   analyzeParagraph,
   generateImageKeywords,
   generateParagraphAxes,
+  extractMainKeyword,
 } from '../utils/groqNews';
 import { useLanguage } from '../context/LanguageContext';
 import { Loader2, Twitter, Facebook, Linkedin, Download, Copy as CopyIcon } from 'lucide-react';
@@ -102,8 +103,13 @@ export default function ContentGenerator() {
     URL.revokeObjectURL(url);
   };
 
+  const handleHumanize = () => {
+    const text = paragraphs.join('\n\n');
+    navigate('/humanize', { state: { text } });
+  };
+
   const handleChooseImage = async () => {
-    let q = keywords[0] ?? '';
+    let q = extractMainKeyword(topic);
     try {
       const aiKw = await generateImageKeywords(topic, 3);
       if (aiKw && aiKw.length > 0) {
@@ -322,8 +328,14 @@ export default function ContentGenerator() {
       {paragraphs.length > 0 && (
         <div className="mt-6 flex justify-end">
           <button
-            onClick={handleChooseImage}
+            onClick={handleHumanize}
             className="px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 text-sm"
+          >
+            Humaniser le texte
+          </button>
+          <button
+            onClick={handleChooseImage}
+            className="ml-2 px-4 py-2 bg-brand text-white rounded hover:bg-brand-600 text-sm"
           >
             Choisir une image
           </button>

--- a/src/utils/groqNews.js
+++ b/src/utils/groqNews.js
@@ -532,6 +532,18 @@ export async function generateImageKeywords(title, count = 3) {
     .slice(0, count);
 }
 
+export function extractMainKeyword(title = '') {
+  if (!title) return '';
+  const tokens = title.match(/[A-Za-zÀ-ÖØ-öø-ÿ0-9]+/g) || [];
+  const stops = new Set([
+    'the','a','an','and','or','for','with','to','of','in','on','secret','revealed',
+    'photos','photo','rock','world','tech'
+  ]);
+  const filtered = tokens.filter(t => !stops.has(t.toLowerCase()));
+  const arr = filtered.length > 0 ? filtered : tokens;
+  return arr.slice(0,2).join(' ');
+}
+
 /**
  * Return a short axis (main idea) for each paragraph.
  * @param {string[]} paragraphs
@@ -568,7 +580,7 @@ export async function humanizeText(text, tone = 'conversation') {
   const instruction = toneMap[tone] || toneMap.conversation;
   const result = await chatCompletion(
     [
-      { role: 'system', content: `${instruction} Keep the original meaning and improve flow.` },
+      { role: 'system', content: `${instruction} Keep the original meaning and improve flow. Reply in French.` },
       { role: 'user', content: text.slice(0, 6000) }
     ],
     { max_tokens: 2000, temperature: 0.7 }


### PR DESCRIPTION
## Summary
- ensure Groq humanization replies in French
- extract main keyword from article titles
- link content generator to humanizer
- better keyword for image search

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6878f4bffa9883318f44e583a5a7915c