### PR TITLE
Add carousel and new pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,8 @@ import Humanize from "./pages/Humanize";
 import ChatBotWidget from './components/ChatBotWidget';
 import { ChatProvider } from './context/ChatContext';
 import AutoTranslate from './pages/AutoTranslate';
+import LaureataResources from './pages/LaureataResources';
+import LessonPython from './pages/LessonPython';
 
 export default function App() {
   const { dark, toggle } = useTheme();
@@ -57,6 +59,8 @@ export default function App() {
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/notifications" element={<Notifications />} />
                   <Route path="/profile" element={<Profile />} />
+                  <Route path="/laureata-resources" element={<LaureataResources />} />
+                  <Route path="/lesson-python" element={<LessonPython />} />
                 </Routes>
               </motion.div>
             </AnimatePresence>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
   Bell,
   Pencil,
   Brain,
+  Library,
 } from 'lucide-react';
 
 export const navItems = [
@@ -28,6 +29,8 @@ export const navItems = [
   { to: '/planning', label: 'Planification de contenu', icon: Calendar },
   { to: '/notifications', label: 'Notifications', icon: Bell },
   { to: '/settings', label: 'Paramètres', icon: SettingsIcon },
+  { to: '/laureata-resources', label: 'Ressources Laureata', icon: Library },
+  { to: '/lesson-python', label: 'Leçon Python', icon: Library },
 ];
 
 export default function Sidebar() {

--- a/src/components/SimpleCarousel.jsx
+++ b/src/components/SimpleCarousel.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function SimpleCarousel({ slides, auto = true, interval = 5000 }) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!auto) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % slides.length);
+    }, interval);
+    return () => clearInterval(id);
+  }, [auto, interval, slides.length]);
+
+  const next = () => setIndex((i) => (i + 1) % slides.length);
+  const prev = () => setIndex((i) => (i - 1 + slides.length) % slides.length);
+
+  return (
+    <div className="relative overflow-hidden">
+      <AnimatePresence initial={false} mode="wait">
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, x: 50 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -50 }}
+          transition={{ duration: 0.5 }}
+          className="h-64 flex items-center justify-center bg-gray-200 dark:bg-gray-800 rounded-lg"
+        >
+          {slides[index]}
+        </motion.div>
+      </AnimatePresence>
+      {slides.length > 1 && (
+        <>
+          <button
+            onClick={prev}
+            className="absolute left-2 top-1/2 -translate-y-1/2 p-2 bg-white/70 dark:bg-gray-900/70 rounded-full"
+          >
+            &#9664;
+          </button>
+          <button
+            onClick={next}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-2 bg-white/70 dark:bg-gray-900/70 rounded-full"
+          >
+            &#9654;
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import GNewsFeed from '../components/GNewsFeed';
 import AITechNewsFeed from '../components/AITechNewsFeed';
 import TechnologyNews from '../components/TechnologyNews';
 import { useChatContext } from '../context/ChatContext';
+import SimpleCarousel from '../components/SimpleCarousel';
 
 export default function Dashboard() {
   const { setOnAction } = useChatContext();
@@ -21,6 +22,22 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
+      <SimpleCarousel
+        slides={[
+          <div className="p-6 text-center">Bienvenue sur SmartNews360</div>,
+          <div className="p-6 text-center">
+            <a
+              href="https://maps.app.goo.gl/p8MrfxUGXziBnwgw5"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline"
+            >
+              Voir notre emplacement
+            </a>
+          </div>,
+          <div className="p-6 text-center">Suivez l'actualité avec nous</div>,
+        ]}
+      />
       <section className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         <div className="space-y-6">
           <div>

--- a/src/pages/LaureataResources.jsx
+++ b/src/pages/LaureataResources.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import SimpleCarousel from '../components/SimpleCarousel';
+
+export default function LaureataResources() {
+  const slides = [
+    <div className="p-6 text-center">Ressource 1</div>,
+    <div className="p-6 text-center">Ressource 2</div>,
+    <div className="p-6 text-center">Ressource 3</div>,
+  ];
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">Ressources pour Laureata</h1>
+      <SimpleCarousel slides={slides} />
+    </div>
+  );
+}

--- a/src/pages/LessonPython.jsx
+++ b/src/pages/LessonPython.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import SimpleCarousel from '../components/SimpleCarousel';
+
+export default function LessonPython() {
+  const slides = [
+    <div className="p-6 text-center">
+      <h2 className="text-xl font-semibold mb-2">Structures de données</h2>
+      <p>Python offre des listes, tuples et dictionnaires pour organiser vos informations.</p>
+    </div>,
+    <div className="p-6 text-center">
+      <h2 className="text-xl font-semibold mb-2">Fonctions</h2>
+      <p>Créez des fonctions pour réutiliser votre code et le garder lisible.</p>
+    </div>,
+    <div className="p-6 text-center">
+      <h2 className="text-xl font-semibold mb-2">Conseil</h2>
+      <p>Utilisez des noms clairs et des structures simples pour conseiller efficacement.</p>
+    </div>,
+  ];
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold text-gray-800 dark:text-gray-100">Leçon Python</h1>
+      <SimpleCarousel slides={slides} auto={false} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SimpleCarousel` component
- integrate carousel on Dashboard with map link
- add Laureata resources and Python lesson pages
- update sidebar navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878fc64054483318e9e71b48c95cc21